### PR TITLE
perf: cache perchlorate query mol in InChI rCleanUp()

### DIFF
--- a/External/INCHI-API/inchi.cpp
+++ b/External/INCHI-API/inchi.cpp
@@ -70,6 +70,7 @@
 #include <queue>
 #include "inchi.h"
 #include <algorithm>
+#include <mutex>
 
 #include <RDGeneral/BoostStartInclude.h>
 #include <tuple>
@@ -1692,10 +1693,13 @@ void fixOptionSymbol(const char *in, char *out) {
 
 /*! "reverse" clean up: prepare a molecule to be used with InChI sdk */
 void rCleanUp(RWMol &mol) {
-  RWMol *q = SmilesToMol("[O-][Cl+3]([O-])([O-])O");
+  static std::once_flag q_init_once;
+  static RWMol *q;
+  std::call_once(q_init_once, []() {
+    q = SmilesToMol("[O-][Cl+3]([O-])([O-])O");
+  });
   std::vector<MatchVectType> fgpMatches;
   SubstructMatch(mol, *q, fgpMatches);
-  delete q;
   // replace all matches
   for (auto match : fgpMatches) {
     // collect matching atoms


### PR DESCRIPTION
*summary by opus-4.6 via opencode:*

Cache the perchlorate SMARTS query molecule as a static local in `rCleanUp()` instead of re-parsing it on every call.

**Benchmark (16 rounds × 800 samples, interleaved, Bonferroni-corrected α=0.002):**
- `MolToInchi`: **-11.5%** (p≈0)

No other benchmarks significant.

<details>
<summary>Benchmark Results (vs master)</summary>

| Benchmark | Old (mean±sd) | New (mean±sd) | Δ% | CV | Speed | Sig(p) |
|:---|---:|---:|---:|---:|:---|:---|
| bench_common::nth_random | 1.3 ns ± 0.0958 ns | 1.38 ns ± 0.142 ns | +6.1% | 10.3% | 1.06× slower | ns p=0.0745 |
| Chirality::findPotentialStereo | 1.6 ms ± 76.2 us | 1.57 ms ± 76.6 us | -2.0% | 4.9% | 1.02× faster | ns p=0.245 |
| CIPLabeler::assignCIPLabels | 583 ms ± 35.5 ms | 572 ms ± 34.8 ms | -1.8% | 6.1% | 1.02× faster | ns p=0.404 |
| Descriptors::calcNumBridgeheadAtoms | 4.49 us ± 367 ns | 4.25 us ± 405 ns | -5.3% | 9.5% | 1.06× faster | ns p=0.0896 |
| Descriptors::calcNumSpiroAtoms | 5.08 us ± 590 ns | 5.07 us ± 607 ns | -0.3% | 12.0% | 1.00× faster | ns p=0.942 |
| InchiToInchiKey | 51.3 us ± 3.75 us | 48.2 us ± 4.61 us | -6.0% | 9.5% | 1.06× faster | ns p=0.0466 |
| InchiToMol | 10.6 ms ± 212 us | 10.5 ms ± 224 us | -0.3% | 2.1% | 1.00× faster | ns p=0.734 |
| memory pressure test | 17.4 us ± 3.19 us | 17.7 us ± 3.54 us | +2.0% | 20.0% | 1.02× slower | ns p=0.776 |
| MolOps::addHs | 778 us ± 47.6 us | 778 us ± 51.6 us | -0.1% | 6.6% | 1.00× faster | ns p=0.956 |
| MolOps::assignStereochemistry legacy=false | 1.97 ms ± 91.3 us | 1.92 ms ± 77.6 us | -2.7% | 4.6% | 1.03× faster | ns p=0.0864 |
| MolOps::assignStereochemistry legacy=true | 1.14 ms ± 56.1 us | 1.13 ms ± 51.4 us | -0.7% | 4.9% | 1.01× faster | ns p=0.683 |
| MolOps::FindSSR | 371 us ± 24.5 us | 376 us ± 17.4 us | +1.5% | 6.6% | 1.02× slower | ns p=0.461 |
| MolOps::getMolFrags | 2.3 ms ± 89.3 us | 2.32 ms ± 99.4 us | +0.6% | 4.3% | 1.01× slower | ns p=0.657 |
| MolPickler::molFromPickle | 305 us ± 22.3 us | 295 us ± 19.3 us | -3.5% | 7.3% | 1.04× faster | ns p=0.157 |
| MolPickler::pickleMol | 273 us ± 16.9 us | 279 us ± 16.9 us | +2.1% | 6.2% | 1.02× slower | ns p=0.347 |
| MolToCXSmiles | 2.58 ms ± 103 us | 2.59 ms ± 132 us | +0.3% | 5.1% | 1.00× slower | ns p=0.876 |
| MolToInchi | 6.17 ms ± 106 us | 5.46 ms ± 122 us | -11.5% | 2.2% | 1.13× faster | sig p=0 |
| MolToSmiles | 1.98 ms ± 95.8 us | 2 ms ± 88.9 us | +0.9% | 4.8% | 1.01× slower | ns p=0.583 |
| MorganFingerprints::getFingerprint | 618 us ± 33.5 us | 629 us ± 22.2 us | +1.7% | 5.4% | 1.02× slower | ns p=0.294 |
| ROMol copy constructor | 150 us ± 11.8 us | 145 us ± 12.3 us | -3.2% | 8.4% | 1.03× faster | ns p=0.265 |
| ROMol destructor | 64.1 us ± 4.15 us | 62.8 us ± 3.75 us | -2.1% | 6.5% | 1.02× faster | ns p=0.339 |
| ROMol::getNumHeavyAtoms | 339 ns ± 22.2 ns | 356 ns ± 25.7 ns | +4.9% | 7.2% | 1.05× slower | ns p=0.059 |
| ROMol::GetSubstructMatch | 113 us ± 9.43 us | 114 us ± 9.67 us | +1.3% | 8.4% | 1.01× slower | ns p=0.66 |
| ROMol::GetSubstructMatch patty | 3.66 ms ± 93.6 us | 3.64 ms ± 77.1 us | -0.6% | 2.6% | 1.01× faster | ns p=0.444 |
| ROMol::GetSubstructMatch RLewis | 22.2 ms ± 398 us | 22.1 ms ± 378 us | -0.6% | 1.8% | 1.01× faster | ns p=0.307 |
| SmilesToMol | 2.96 ms ± 113 us | 3.01 ms ± 109 us | +1.7% | 3.8% | 1.02× slower | ns p=0.214 |

_Summary: sig=1, below=0 (stat-sig but < threshold), ns=25, missing=0, new_only=0
Bonferroni-corrected α = 0.001923 (26 tests, family α = 0.05)_

</details>
