### PR TITLE
perf: shorten hot-path property name strings (_CIPRank→_R, RecursiveStructure→RS)

### DIFF
--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -1295,7 +1295,7 @@ void mergeQueryHs(RWMol &mol, bool mergeUnmappedOnly, bool mergeIsotopes) {
 
       // recurse if needed (was github isusue 544)
       if (atom->hasQuery()) {
-        if (atom->getQuery()->getDescription() == "RecursiveStructure") {
+        if (atom->getQuery()->getDescription() == "RS") {
           auto *rsq = dynamic_cast<RecursiveStructureQuery *>(atom->getQuery());
           CHECK_INVARIANT(rsq, "could not convert recursive structure query");
           RWMol *rqm = new RWMol(*rsq->getQueryMol());
@@ -1309,7 +1309,7 @@ void mergeQueryHs(RWMol &mol, bool mergeUnmappedOnly, bool mergeIsotopes) {
         while (childStack.size()) {
           QueryAtom::QUERYATOM_QUERY::CHILD_TYPE qry = childStack.front();
           childStack.pop_front();
-          if (qry->getDescription() == "RecursiveStructure") {
+          if (qry->getDescription() == "RS") {
             auto *rsq = dynamic_cast<RecursiveStructureQuery *>(qry.get());
             CHECK_INVARIANT(rsq, "could not convert recursive structure query");
             RWMol *rqm = new RWMol(*rsq->getQueryMol());
@@ -1363,7 +1363,7 @@ std::pair<bool, bool> hasQueryHs(const ROMol &mol) {
         break;
     }
     if (atom->hasQuery()) {
-      if (atom->getQuery()->getDescription() == "RecursiveStructure") {
+      if (atom->getQuery()->getDescription() == "RS") {
         auto *rsq = dynamic_cast<RecursiveStructureQuery *>(atom->getQuery());
         CHECK_INVARIANT(rsq, "could not convert recursive structure query");
         auto res = hasQueryHs(*rsq->getQueryMol());
@@ -1379,7 +1379,7 @@ std::pair<bool, bool> hasQueryHs(const ROMol &mol) {
       while (!childStack.empty()) {
         QueryAtom::QUERYATOM_QUERY::CHILD_TYPE qry = childStack.front();
         childStack.pop_front();
-        if (qry->getDescription() == "RecursiveStructure") {
+        if (qry->getDescription() == "RS") {
           auto *rsq = dynamic_cast<RecursiveStructureQuery *>(qry.get());
           CHECK_INVARIANT(rsq, "could not convert recursive structure query");
           auto res = hasQueryHs(*rsq->getQueryMol());

--- a/Code/GraphMol/QueryOps.cpp
+++ b/Code/GraphMol/QueryOps.cpp
@@ -1125,9 +1125,11 @@ void finalizeQueryFromDescription(
     query->setDataFunc(queryAtomType);
   } else if (descr == "AtomNumRadicalElectrons") {
     query->setDataFunc(queryAtomNumRadicalElectrons);
-  } else if (descr == "AtomInNRings" || descr == "RS") {
-    // don't need to do anything here because the classes
-    // automatically have everything set
+  } else if (descr == "AtomInNRings" || descr == "RS" ||
+             descr == "RecursiveStructure") {
+    if (descr == "RecursiveStructure") {
+      query->setDescription("RS");
+    }
   } else if (descr == "AtomAnd" || descr == "AtomOr" || descr == "AtomXor" ||
              descr == "HasProp" || descr == "HasPropWithValue") {
     // don't need to do anything here because the classes

--- a/Code/GraphMol/QueryOps.cpp
+++ b/Code/GraphMol/QueryOps.cpp
@@ -1125,7 +1125,7 @@ void finalizeQueryFromDescription(
     query->setDataFunc(queryAtomType);
   } else if (descr == "AtomNumRadicalElectrons") {
     query->setDataFunc(queryAtomNumRadicalElectrons);
-  } else if (descr == "AtomInNRings" || descr == "RecursiveStructure") {
+  } else if (descr == "AtomInNRings" || descr == "RS") {
     // don't need to do anything here because the classes
     // automatically have everything set
   } else if (descr == "AtomAnd" || descr == "AtomOr" || descr == "AtomXor" ||

--- a/Code/GraphMol/QueryOps.h
+++ b/Code/GraphMol/QueryOps.h
@@ -752,7 +752,7 @@ class RDKIT_GRAPHMOL_EXPORT RecursiveStructureQuery
  public:
   RecursiveStructureQuery() : Queries::SetQuery<int, Atom const *, true>() {
     setDataFunc(getAtIdx);
-    setDescription("RecursiveStructure");
+    setDescription("RS");
   }
   //! initialize from an ROMol pointer
   /*!
@@ -764,7 +764,7 @@ class RDKIT_GRAPHMOL_EXPORT RecursiveStructureQuery
         d_serialNumber(serialNumber) {
     setQueryMol(query);
     setDataFunc(getAtIdx);
-    setDescription("RecursiveStructure");
+    setDescription("RS");
   }
   //! returns the index of an atom
   static inline int getAtIdx(Atom const *at) {

--- a/Code/GraphMol/SmilesParse/SmartsWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmartsWrite.cpp
@@ -339,7 +339,7 @@ std::string getAtomSmartsSimple(const QueryAtom *qatom,
 std::string getRecursiveStructureQuerySmarts(
     const QueryAtom::QUERYATOM_QUERY *query, const SmilesWriteParams &params) {
   PRECONDITION(query, "bad query");
-  PRECONDITION(query->getDescription() == "RecursiveStructure", "bad query");
+  PRECONDITION(query->getDescription() == "RS", "bad query");
   const auto *rquery = dynamic_cast<const RecursiveStructureQuery *>(query);
   PRECONDITION(rquery, "could not convert query to RecursiveStructureQuery");
   auto *qmol = const_cast<ROMol *>(rquery->getQueryMol());
@@ -505,7 +505,7 @@ std::string _recurseGetSmarts(const QueryAtom *qatom,
   bool needParen;
   std::string csmarts1;
   // deal with the first child
-  if (dsc1 == "RecursiveStructure") {
+  if (dsc1 == "RS") {
     csmarts1 = getRecursiveStructureQuerySmarts(child1, params);
     features |= static_cast<unsigned int>(QueryBoolFeatures::HAS_RECURSION);
   } else if ((dsc1 != "AtomOr") && (dsc1 != "AtomAnd")) {
@@ -541,7 +541,7 @@ std::string _recurseGetSmarts(const QueryAtom *qatom,
     std::string csmarts2;
 
     // deal with the next child
-    if (dsc2 == "RecursiveStructure") {
+    if (dsc2 == "RS") {
       csmarts2 = getRecursiveStructureQuerySmarts(child2, params);
       features |= static_cast<unsigned int>(QueryBoolFeatures::HAS_RECURSION);
     } else if ((dsc2 != "AtomOr") && (dsc2 != "AtomAnd")) {
@@ -921,7 +921,7 @@ std::string GetAtomSmarts(const Atom *atom, const SmilesWriteParams &params) {
       if (res.length() == 1) {  // single atom symbol we don't need parens
         needParen = false;
       }
-    } else if (descrip == "RecursiveStructure") {
+    } else if (descrip == "RS") {
       // it's a bare recursive structure query:
       res = getRecursiveStructureQuerySmarts(query, params);
       needParen = true;

--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -665,7 +665,7 @@ void MatchSubqueries(const ROMol &mol, QueryAtom::QUERYATOM_QUERY *query,
                      SUBQUERY_MAP &subqueryMap,
                      std::vector<RecursiveStructureQuery *> &locked) {
   PRECONDITION(query, "bad query");
-  if (query->getDescription() == "RecursiveStructure") {
+  if (query->getDescription() == "RS") {
     auto *rsq = (RecursiveStructureQuery *)query;
 #ifdef RDK_BUILD_THREADSAFE_SSS
     rsq->d_mutex.lock();

--- a/Code/GraphMol/SubstructLibrary/SubstructLibrary.cpp
+++ b/Code/GraphMol/SubstructLibrary/SubstructLibrary.cpp
@@ -178,7 +178,7 @@ bool query_needs_rings(const ROMol &in_query) {
     if (atom->hasQuery()) {
       if (describeQuery(atom).find("Ring") != std::string::npos) {
         return true;
-      } else if (atom->getQuery()->getDescription() == "RecursiveStructure") {
+      } else if (atom->getQuery()->getDescription() == "RS") {
         auto *rsq = (RecursiveStructureQuery *)atom->getQuery();
         if (query_needs_rings(*rsq->getQueryMol())) {
           return true;

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -4469,17 +4469,17 @@ $$$$
     m = Chem.MolFromSmiles('c1ccccc1C(C)C')
     for atom in m.GetAtoms():
       d = atom.GetPropsAsDict()
-      self.assertEqual(set(d.keys()), set(['_CIPRank', '__computedProps']))
-      self.assertEqual(type(d['_CIPRank']), int)
-      self.assertEqual(list(d['__computedProps']), ['_CIPRank'])
+      self.assertEqual(set(d.keys()), set(['_R', '__computedProps']))
+      self.assertEqual(type(d['_R']), int)
+      self.assertEqual(list(d['__computedProps']), ['_R'])
 
     m = Chem.MolFromSmiles('c1ccccc1')
     self.assertEqual(Chem.ComputeAtomCIPRanks(m), (0, 0, 0, 0, 0, 0))
     for atom in m.GetAtoms():
       d = atom.GetPropsAsDict()
-      self.assertEqual(set(d.keys()), set(['_CIPRank', '__computedProps']))
-      self.assertEqual(d['_CIPRank'], 0)
-      self.assertEqual(list(d['__computedProps']), ['_CIPRank'])
+      self.assertEqual(set(d.keys()), set(['_R', '__computedProps']))
+      self.assertEqual(d['_R'], 0)
+      self.assertEqual(list(d['__computedProps']), ['_R'])
 
     Chem.SetUseLegacyStereoPerception(origVal)
 

--- a/Code/GraphMol/testPickler.cpp
+++ b/Code/GraphMol/testPickler.cpp
@@ -398,7 +398,7 @@ void testQueries() {
   TEST_ASSERT(m1->getNumAtoms() == 1);
   TEST_ASSERT(m1->getAtomWithIdx(0)->hasQuery());
   TEST_ASSERT(m1->getAtomWithIdx(0)->getQuery()->getDescription() ==
-              "RecursiveStructure");
+              "RS");
   smi = "C";
   m2 = SmilesToMol(smi);
   TEST_ASSERT(m2);
@@ -560,7 +560,7 @@ void testQueries() {
   TEST_ASSERT(m1->getNumAtoms() == 1);
   TEST_ASSERT(m1->getAtomWithIdx(0)->hasQuery());
   TEST_ASSERT(m1->getAtomWithIdx(0)->getQuery()->getDescription() ==
-              "RecursiveStructure");
+              "RS");
   smi = "C";
   m2 = SmilesToMol(smi);
   TEST_ASSERT(m2);

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -69,7 +69,7 @@ inline constexpr std::string_view _BondsPotentialStereo =
     "_BondsPotentialStereo";
 inline constexpr std::string_view _ChiralAtomRank = "_chiralAtomRank";
 inline constexpr std::string_view _CIPCode = "_CIPCode";
-inline constexpr std::string_view _CIPRank = "_CIPRank";
+inline constexpr std::string_view _CIPRank = "R";
 inline constexpr std::string_view _CIPComputed = "_CIPComputed";
 inline constexpr std::string_view _CIPNeighborOrder = "_CIPNeighborOrder";
 inline constexpr std::string_view _CanonicalRankingNumber =

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -69,7 +69,7 @@ inline constexpr std::string_view _BondsPotentialStereo =
     "_BondsPotentialStereo";
 inline constexpr std::string_view _ChiralAtomRank = "_chiralAtomRank";
 inline constexpr std::string_view _CIPCode = "_CIPCode";
-inline constexpr std::string_view _CIPRank = "R";
+inline constexpr std::string_view _CIPRank = "_R";
 inline constexpr std::string_view _CIPComputed = "_CIPComputed";
 inline constexpr std::string_view _CIPNeighborOrder = "_CIPNeighborOrder";
 inline constexpr std::string_view _CanonicalRankingNumber =

--- a/rdkit/Chem/Pharm3D/EmbedLib.py
+++ b/rdkit/Chem/Pharm3D/EmbedLib.py
@@ -1272,7 +1272,7 @@ def ComputeChiralVolume(mol, centerIdx, confId=-1):
     return 0.0
 
   nbrs = center.GetNeighbors()
-  nbrRanks = [(int(nbr.GetProp('_CIPRank')), conf.GetAtomPosition(nbr.GetIdx())) for nbr in nbrs]
+  nbrRanks = [(int(nbr.GetProp('_R')), conf.GetAtomPosition(nbr.GetIdx())) for nbr in nbrs]
 
   # if we only have three neighbors (i.e. the determining H isn't present)
   # then use the central atom as the fourth point:


### PR DESCRIPTION
*summary by opus-4.6 via opencode:*

Shorten two frequently-compared property name strings to reduce `memcmp` overhead in Dict lookups:
- `_CIPRank` → `_R` (compared in every atom rank operation)
- `RecursiveStructure` → `RS` (compared in substructure matching)

Includes backward-compat deserialization normalization. The `_R` key uses underscore prefix to preserve private property semantics.

**No significant benchmark impact** (0/26 sig, 3×100 interleaved).

<details>
<summary>Benchmark Results (vs master)</summary>

All benchmarks run with Catch2 v3, Release build. Significance determined by Welch's t-test.

| Benchmark | Old (mean±sd) | New (mean±sd) | Δ% | Speed | Sig(p) |
|:---|---:|---:|---:|:---|:---|
| bench_common::nth_random | 0.585 ns ± 0.0471 ns | 0.558 ns ± 0.0124 ns | -4.7% | 1.05× faster | ns p=0.327 |
| Chirality::findPotentialStereo | 865 us ± 206 us | 632 us ± 41.5 us | -26.9% | 1.37× faster | ns p=0.0552 |
| CIPLabeler::assignCIPLabels | 293 ms ± 2.37 ms | 295 ms ± 5.1 ms | +0.6% | 1.01× slower | ns p=0.557 |
| Descriptors::calcNumBridgeheadAtoms | 1.11 us ± 43.6 ns | 1.52 us ± 772 ns | +36.4% | 1.36× slower | ns p=0.364 |
| Descriptors::calcNumSpiroAtoms | 1.27 us ± 19.8 ns | 1.72 us ± 776 ns | +35.6% | 1.36× slower | ns p=0.314 |
| InchiToInchiKey | 33.5 us ± 1.09 us | 36.5 us ± 5.64 us | +8.8% | 1.09× slower | ns p=0.373 |
| InchiToMol | 4.56 ms ± 333 us | 4.75 ms ± 354 us | +4.1% | 1.04× slower | ns p=0.503 |
| memory pressure test | 9.23 us ± 519 ns | 9.37 us ± 352 ns | +1.5% | 1.02× slower | ns p=0.699 |
| MolOps::addHs | 416 us ± 6.39 us | 428 us ± 7.95 us | +2.7% | 1.03× slower | ns p=0.0552 |
| MolOps::assignStereochemistry legacy=false | 876 us ± 67.4 us | 794 us ± 83.7 us | -9.3% | 1.10× faster | ns p=0.188 |
| MolOps::assignStereochemistry legacy=true | 481 us ± 17.3 us | 487 us ± 18.8 us | +1.4% | 1.01× slower | ns p=0.657 |
| MolOps::FindSSR | 223 us ± 73.5 us | 217 us ± 88.2 us | -2.5% | 1.03× faster | ns p=0.933 |
| MolOps::getMolFrags | 1.11 ms ± 10.3 us | 1.11 ms ± 26.8 us | -0.2% | 1.00× faster | ns p=0.885 |
| MolPickler::molFromPickle | 169 us ± 6.38 us | 185 us ± 25.2 us | +9.7% | 1.10× slower | ns p=0.273 |
| MolPickler::pickleMol | 128 us ± 42.7 us | 106 us ± 6.22 us | -16.7% | 1.20× faster | ns p=0.392 |
| MolToCXSmiles | 1.37 ms ± 101 us | 1.51 ms ± 175 us | +10.0% | 1.10× slower | ns p=0.238 |
| MolToInchi | 2.69 ms ± 939 us | 2.69 ms ± 952 us | -0.1% | 1.00× faster | ns p=0.997 |
| MolToSmiles | 1.12 ms ± 110 us | 1.16 ms ± 202 us | +3.1% | 1.03× slower | ns p=0.795 |
| MorganFingerprints::getFingerprint | 245 us ± 99.3 us | 262 us ± 116 us | +6.9% | 1.07× slower | ns p=0.848 |
| ROMol copy constructor | 44.3 us ± 1.58 us | 60.7 us ± 29.4 us | +37.0% | 1.37× slower | ns p=0.335 |
| ROMol destructor | 23 us ± 9.1 us | 18.4 us ± 672 ns | -20.1% | 1.25× faster | ns p=0.382 |
| ROMol::getNumHeavyAtoms | 130 ns ± 40.2 ns | 106 ns ± 2.17 ns | -18.4% | 1.23× faster | ns p=0.304 |
| ROMol::GetSubstructMatch | 34.6 us ± 352 ns | 36.2 us ± 6.76 us | +4.8% | 1.05× slower | ns p=0.672 |
| ROMol::GetSubstructMatch patty | 1.49 ms ± 446 us | 1.22 ms ± 147 us | -18.0% | 1.22× faster | ns p=0.321 |
| ROMol::GetSubstructMatch RLewis | 7.27 ms ± 107 us | 7.53 ms ± 473 us | +3.5% | 1.03× slower | ns p=0.366 |
| SmilesToMol | 1.5 ms ± 388 us | 1.28 ms ± 29.4 us | -14.5% | 1.17× faster | ns p=0.334 |

_Summary: sig=0, below=0 (stat-sig but < threshold), ns=26, missing=0, new_only=0_

</details>
