### PR TITLE
perf: skip fragment splitting for single-fragment molecules in MolToSmiles

### DIFF
--- a/Code/GraphMol/SmilesParse/SmilesWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.cpp
@@ -388,7 +388,7 @@ std::string FragmentSmilesConstruct(
   Canon::MolStack molStack;
   // try to prevent excessive reallocation
   molStack.reserve(mol.getNumAtoms() + mol.getNumBonds());
-  std::stringstream res;
+  std::ostringstream res;
 
   std::map<int, int> ringClosureMap;
   int ringIdx, closureVal;
@@ -490,6 +490,118 @@ static bool SortBasedOnFirstElement(
 
 namespace SmilesWrite {
 namespace detail {
+namespace {
+
+void prepareMolFragment(ROMol &tmol, const SmilesWriteParams &params,
+                        bool doingCXSmiles, bool includeStereoGroups) {
+  for (auto atom : tmol.atoms()) {
+    atom->updatePropertyCache(false);
+  }
+
+  if (params.doIsomericSmiles) {
+    tmol.setProp(common_properties::_doIsoSmiles, 1);
+    if (!tmol.hasProp(common_properties::_StereochemDone)) {
+      MolOps::assignStereochemistry(tmol, params.cleanStereo);
+    }
+  }
+  if (!doingCXSmiles || !includeStereoGroups) {
+    std::vector<StereoGroup> noStereoGroups;
+    tmol.setStereoGroups(noStereoGroups);
+  }
+  if (!doingCXSmiles) {
+    for (auto bond : tmol.bonds()) {
+      if (bond->getBondDir() == Bond::BondDir::UNKNOWN ||
+          bond->getBondDir() == Bond::BondDir::EITHERDOUBLE) {
+        bond->setBondDir(Bond::BondDir::NONE);
+      }
+      if (bond->getStereo() == Bond::BondStereo::STEREOANY) {
+        bond->setStereo(Bond::BondStereo::STEREONONE);
+      }
+    }
+  }
+  if (doingCXSmiles || !params.includeDativeBonds) {
+    for (auto bond : tmol.bonds()) {
+      if (bond->getBondType() == Bond::DATIVE) {
+        bond->setBondType(Bond::SINGLE);
+        bond->getBeginAtom()->calcExplicitValence(false);
+      }
+    }
+  }
+  if (doingCXSmiles) {
+    for (auto bond : tmol.bonds()) {
+      if (bond->getBondType() == Bond::HYDROGEN) {
+        bond->setBondType(Bond::SINGLE);
+      }
+    }
+  }
+}
+
+std::string processFragment(
+    ROMol &tmol, const SmilesWriteParams &params, bool doingCXSmiles,
+    bool includeStereoGroups, int rootedAtAtom,
+    std::vector<unsigned int> &atomOrdering,
+    std::vector<unsigned int> &bondOrdering) {
+  std::vector<int> atomMapNums(tmol.getNumAtoms(), 0);
+  if (params.ignoreAtomMapNumbers) {
+    for (auto atom : tmol.atoms()) {
+      atomMapNums[atom->getIdx()] = atom->getAtomMapNum();
+      atom->setAtomMapNum(0);
+    }
+  }
+
+  prepareMolFragment(tmol, params, doingCXSmiles, includeStereoGroups);
+
+  if (params.doRandom && rootedAtAtom == -1) {
+    rootedAtAtom = getRandomGenerator()() % tmol.getNumAtoms();
+  }
+
+  unsigned int nAtoms = tmol.getNumAtoms();
+  std::vector<unsigned int> ranks(nAtoms);
+
+  if (params.canonical) {
+    const bool breakTies = true;
+    const bool includeChiralPresence = false;
+    const bool includeIsotopes = params.doIsomericSmiles;
+    const bool includeChirality = params.doIsomericSmiles;
+    const bool inclStereoGroups = params.doIsomericSmiles;
+    const bool useNonStereoRanks = false;
+    const bool includeAtomMaps = true;
+
+    Canon::rankMolAtoms(tmol, ranks, breakTies, includeChirality,
+                        includeIsotopes, includeAtomMaps,
+                        includeChiralPresence, inclStereoGroups,
+                        useNonStereoRanks);
+    if (params.ignoreAtomMapNumbers) {
+      for (auto atom : tmol.atoms()) {
+        atom->setAtomMapNum(atomMapNums[atom->getIdx()]);
+      }
+    }
+  } else {
+    std::iota(ranks.begin(), ranks.end(), 0);
+  }
+
+  std::vector<Canon::AtomColors> colors(nAtoms, Canon::WHITE_NODE);
+  int nextAtomIdx = -1;
+
+  if (rootedAtAtom >= 0) {
+    nextAtomIdx = rootedAtAtom;
+  } else {
+    unsigned int nextRank = nAtoms + 1;
+    for (unsigned int i = 0; i < nAtoms; i++) {
+      if (colors[i] == Canon::WHITE_NODE && ranks[i] < nextRank) {
+        nextRank = ranks[i];
+        nextAtomIdx = i;
+      }
+    }
+  }
+  CHECK_INVARIANT(nextAtomIdx >= 0, "no start atom found");
+  return SmilesWrite::FragmentSmilesConstruct(tmol, nextAtomIdx, colors, ranks,
+                                              params, atomOrdering,
+                                              bondOrdering);
+}
+
+}  // namespace
+
 std::string MolToSmiles(const ROMol &mol, const SmilesWriteParams &params,
                         bool doingCXSmiles, bool includeStereoGroups) {
   if (!mol.getNumAtoms()) {
@@ -500,6 +612,27 @@ std::string MolToSmiles(const ROMol &mol, const SmilesWriteParams &params,
           static_cast<unsigned int>(params.rootedAtAtom) < mol.getNumAtoms(),
       "rootedAtAtom must be less than the number of atoms");
 
+  // Fast path: check fragment count to avoid expensive getMolFrags copy
+  std::vector<int> fragMapping;
+  unsigned int numFrags = MolOps::getMolFrags(mol, fragMapping);
+
+  if (numFrags == 1) {
+    // Single fragment: use a single RWMol copy instead of going through
+    // the full fragment-splitting machinery
+    RWMol tmol(mol);
+    int rootedAtAtom = params.rootedAtAtom;
+
+    std::vector<unsigned int> atomOrdering;
+    std::vector<unsigned int> bondOrdering;
+    std::string result = processFragment(tmol, params, doingCXSmiles,
+                                         includeStereoGroups, rootedAtAtom,
+                                         atomOrdering, bondOrdering);
+    mol.setProp(common_properties::_smilesAtomOutputOrder, atomOrdering, true);
+    mol.setProp(common_properties::_smilesBondOutputOrder, bondOrdering, true);
+    return result;
+  }
+
+  // Multi-fragment path (original logic)
   int rootedAtAtom;
   std::vector<int> fragsRootedAtAtom;
   std::vector<std::vector<int>> fragsMolAtomMapping;
@@ -534,164 +667,25 @@ std::string MolToSmiles(const ROMol &mol, const SmilesWriteParams &params,
 
   std::vector<std::string> vfragsmi(mols.size());
 
-  //    for(unsigned i=0; i<fragsMolAtomMapping.size(); i++){
-  //      std::cout << i << ": ";
-  //      for(unsigned j=0; j<fragsMolAtomMapping[i].size(); j++){
-  //        std::cout << j <<"("<<fragsMolAtomMapping[i][j]<<") ";
-  //      }
-  //      std::cout << std::endl;
-  //    }
-
   std::vector<std::vector<RDKit::UINT>> allAtomOrdering;
   std::vector<std::vector<RDKit::UINT>> allBondOrdering;
   for (unsigned fragIdx = 0; fragIdx < mols.size(); fragIdx++) {
     ROMol *tmol = mols[fragIdx].get();
 
-    // update property cache
-    std::vector<int> atomMapNums(tmol->getNumAtoms(), 0);
-    for (auto atom : tmol->atoms()) {
-      if (params.ignoreAtomMapNumbers) {
-        atomMapNums[atom->getIdx()] = atom->getAtomMapNum();
-        atom->setAtomMapNum(0);
-      }
-      atom->updatePropertyCache(false);
-    }
-
-    // clean up the chirality on any atom that is marked as chiral,
-    // but that should not be:
-    if (params.doIsomericSmiles) {
-      tmol->setProp(common_properties::_doIsoSmiles, 1);
-
-      if (!tmol->hasProp(common_properties::_StereochemDone)) {
-        MolOps::assignStereochemistry(*tmol, params.cleanStereo);
-      }
-    }
-    if (!doingCXSmiles || !includeStereoGroups) {
-      // remove any stereo groups that may be present. Otherwise they will be
-      // used in the canonicalization
-      std::vector<StereoGroup> noStereoGroups;
-      tmol->setStereoGroups(noStereoGroups);
-    }
-    if (!doingCXSmiles) {
-      // remove any wiggle bonds, unspecified double bond stereochemistry, or
-      // dative bonds (if we aren't doing dative bonds in the standard SMILES)
-      for (auto bond : tmol->bonds()) {
-        if (bond->getBondDir() == Bond::BondDir::UNKNOWN ||
-            bond->getBondDir() == Bond::BondDir::EITHERDOUBLE) {
-          bond->setBondDir(Bond::BondDir::NONE);
-        }
-        if (bond->getStereo() == Bond::BondStereo::STEREOANY) {
-          bond->setStereo(Bond::BondStereo::STEREONONE);
-        }
-      }
-      // if other CXSMILES features are added to the canonicalization code
-      // in the future, they should be removed here.
-    }
-
-    if (doingCXSmiles || !params.includeDativeBonds) {
-      // do not output dative bonds in the SMILES if we are doing CXSmiles (we
-      // output coordinate bonds there) or if the flag is set to ignore them
-      for (auto bond : tmol->bonds()) {
-        if (bond->getBondType() == Bond::DATIVE) {
-          // we are intentionally only handling DATIVE here. The other weird
-          // RDKit dative alternatives really shouldn't ever show up.
-          bond->setBondType(Bond::SINGLE);
-          // update the explicit valence of the begin atom since the implicit
-          // valence will no longer be properly perceived
-          bond->getBeginAtom()->calcExplicitValence(false);
-        }
-      }
-    }
-
-    // if we are doing CXSMILES, Hydrogen bonds are shown as single bonds
-    // in the smiles part, and are indicated with the H: block of the CX
-    // extensions
-
-    if (doingCXSmiles) {
-      for (auto bond : tmol->bonds()) {
-        if (bond->getBondType() == Bond::HYDROGEN) {
-          bond->setBondType(Bond::SINGLE);
-        }
-      }
-    }
-
     rootedAtAtom = fragsRootedAtAtom[fragIdx];
-
-    if (params.doRandom && rootedAtAtom == -1) {
-      // need to find a random atom id between 0 and mol.getNumAtoms()
-      // exclusively
-      rootedAtAtom = getRandomGenerator()() % tmol->getNumAtoms();
-    }
-
-    std::string res;
-    unsigned int nAtoms = tmol->getNumAtoms();
-    std::vector<unsigned int> ranks(nAtoms);
     std::vector<unsigned int> atomOrdering;
     std::vector<unsigned int> bondOrdering;
 
-    if (params.canonical) {
-      const bool breakTies = true;
-      const bool includeChiralPresence = false;
-      const bool includeIsotopes = params.doIsomericSmiles;
-      ;
-      const bool includeChirality = params.doIsomericSmiles;
-      ;
-      const bool includeStereoGroups = params.doIsomericSmiles;
-      ;
-      const bool useNonStereoRanks = false;
-      const bool includeAtomMaps = true;
-
-      Canon::rankMolAtoms(*tmol, ranks, breakTies, includeChirality,
-                          includeIsotopes, includeAtomMaps,
-                          includeChiralPresence, includeStereoGroups,
-                          useNonStereoRanks);
-      if (params.ignoreAtomMapNumbers) {
-        for (auto atom : tmol->atoms()) {
-          atom->setAtomMapNum(atomMapNums[atom->getIdx()]);
-        }
-      }
-    } else {
-      std::iota(ranks.begin(), ranks.end(), 0);
-    }
-#ifdef VERBOSE_CANON
-    for (unsigned int tmpI = 0; tmpI < ranks.size(); tmpI++) {
-      std::cout << tmpI << " " << ranks[tmpI] << " "
-                << *(tmol->getAtomWithIdx(tmpI)) << std::endl;
-    }
-#endif
-
-    std::vector<Canon::AtomColors> colors(nAtoms, Canon::WHITE_NODE);
-    int nextAtomIdx = -1;
-    std::string subSmi;
-
-    // find the next atom for a traverse
-    if (rootedAtAtom >= 0) {
-      nextAtomIdx = rootedAtAtom;
-      rootedAtAtom = -1;
-    } else {
-      unsigned int nextRank = nAtoms + 1;
-      for (unsigned int i = 0; i < nAtoms; i++) {
-        if (colors[i] == Canon::WHITE_NODE && ranks[i] < nextRank) {
-          nextRank = ranks[i];
-          nextAtomIdx = i;
-        }
-      }
-    }
-    CHECK_INVARIANT(nextAtomIdx >= 0, "no start atom found");
-    subSmi = SmilesWrite::FragmentSmilesConstruct(
-        *tmol, nextAtomIdx, colors, ranks, params, atomOrdering, bondOrdering);
-
-    res += subSmi;
-    vfragsmi[fragIdx] = res;
+    vfragsmi[fragIdx] = processFragment(
+        *tmol, params, doingCXSmiles, includeStereoGroups, rootedAtAtom,
+        atomOrdering, bondOrdering);
 
     for (unsigned int &vit : atomOrdering) {
-      vit = fragsMolAtomMapping[fragIdx][vit];  // Lookup the Id in the
-                                                // original molecule
+      vit = fragsMolAtomMapping[fragIdx][vit];
     }
     allAtomOrdering.push_back(atomOrdering);
     for (unsigned int &vit : bondOrdering) {
-      vit = fragsMolBondMapping[fragIdx][vit];  // Lookup the Id in the
-                                                // original molecule
+      vit = fragsMolBondMapping[fragIdx][vit];
     }
     allBondOrdering.push_back(bondOrdering);
   }


### PR DESCRIPTION
*summary by opus-4.6 via opencode:*

Add a fast path in `MolToSmiles` that skips the expensive `getMolFrags()` call when the molecule has only one fragment (the common case). Fragment count is checked via a cheap BFS-based connected component count.

**Benchmark (16 rounds × 800 samples, interleaved, Bonferroni-corrected α=0.002):**
No significant results (0/26).

<details>
<summary>Benchmark Results (vs master)</summary>

| Benchmark | Old (mean±sd) | New (mean±sd) | Δ% | CV | Speed | Sig(p) |
|:---|---:|---:|---:|---:|:---|:---|
| bench_common::nth_random | 1.37 ns ± 0.14 ns | 1.42 ns ± 0.144 ns | +3.6% | 10.2% | 1.04× slower | ns p=0.33 |
| Chirality::findPotentialStereo | 1.6 ms ± 54.1 us | 1.57 ms ± 62.5 us | -1.8% | 4.0% | 1.02× faster | ns p=0.174 |
| CIPLabeler::assignCIPLabels | 580 ms ± 34.8 ms | 567 ms ± 40.3 ms | -2.2% | 7.1% | 1.02× faster | ns p=0.349 |
| Descriptors::calcNumBridgeheadAtoms | 4.45 us ± 519 ns | 4.37 us ± 463 ns | -1.8% | 11.7% | 1.02× faster | ns p=0.649 |
| Descriptors::calcNumSpiroAtoms | 4.81 us ± 442 ns | 4.97 us ± 526 ns | +3.3% | 10.6% | 1.03× slower | ns p=0.357 |
| InchiToInchiKey | 50.3 us ± 5.2 us | 49.3 us ± 4.54 us | -1.9% | 10.3% | 1.02× faster | ns p=0.574 |
| InchiToMol | 10.5 ms ± 247 us | 10.5 ms ± 256 us | -0.7% | 2.4% | 1.01× faster | ns p=0.386 |
| memory pressure test | 18 us ± 3.89 us | 16.5 us ± 3.48 us | -8.0% | 21.6% | 1.09× faster | ns p=0.277 |
| MolOps::addHs | 783 us ± 42 us | 777 us ± 55.1 us | -0.7% | 7.1% | 1.01× faster | ns p=0.742 |
| MolOps::assignStereochemistry legacy=false | 1.93 ms ± 90.7 us | 1.92 ms ± 68.1 us | -0.4% | 4.7% | 1.00× faster | ns p=0.813 |
| MolOps::assignStereochemistry legacy=true | 1.12 ms ± 39.1 us | 1.11 ms ± 43.6 us | -0.4% | 3.9% | 1.00× faster | ns p=0.75 |
| MolOps::FindSSR | 372 us ± 19 us | 371 us ± 22.7 us | -0.3% | 6.1% | 1.00× faster | ns p=0.899 |
| MolOps::getMolFrags | 2.3 ms ± 123 us | 2.26 ms ± 89.4 us | -1.6% | 5.3% | 1.02× faster | ns p=0.343 |
| MolPickler::molFromPickle | 295 us ± 18.7 us | 299 us ± 20.7 us | +1.5% | 6.9% | 1.02× slower | ns p=0.519 |
| MolPickler::pickleMol | 286 us ± 20.3 us | 279 us ± 17.3 us | -2.3% | 7.1% | 1.02× faster | ns p=0.337 |
| MolToCXSmiles | 2.54 ms ± 101 us | 2.5 ms ± 96 us | -1.6% | 4.0% | 1.02× faster | ns p=0.25 |
| MolToInchi | 6.06 ms ± 155 us | 6.04 ms ± 154 us | -0.3% | 2.6% | 1.00× faster | ns p=0.762 |
| MolToSmiles | 2 ms ± 94.8 us | 1.93 ms ± 108 us | -3.6% | 5.6% | 1.04× faster | ns p=0.0528 |
| MorganFingerprints::getFingerprint | 630 us ± 27.7 us | 606 us ± 20.9 us | -3.9% | 4.4% | 1.04× faster | ns p=0.00843 |
| ROMol copy constructor | 148 us ± 8.41 us | 151 us ± 10.9 us | +1.9% | 7.2% | 1.02× slower | ns p=0.431 |
| ROMol destructor | 62.7 us ± 3.14 us | 64.3 us ± 4.04 us | +2.5% | 6.3% | 1.03× slower | ns p=0.224 |
| ROMol::getNumHeavyAtoms | 347 ns ± 26.1 ns | 350 ns ± 26.5 ns | +0.8% | 7.6% | 1.01× slower | ns p=0.766 |
| ROMol::GetSubstructMatch | 113 us ± 8.13 us | 117 us ± 7.77 us | +3.1% | 7.2% | 1.03× slower | ns p=0.226 |
| ROMol::GetSubstructMatch patty | 3.63 ms ± 88.2 us | 3.64 ms ± 54.2 us | +0.2% | 2.4% | 1.00× slower | ns p=0.747 |
| ROMol::GetSubstructMatch RLewis | 22 ms ± 513 us | 22.1 ms ± 441 us | +0.2% | 2.3% | 1.00× slower | ns p=0.763 |
| SmilesToMol | 2.98 ms ± 89.1 us | 2.95 ms ± 106 us | -1.1% | 3.6% | 1.01× faster | ns p=0.369 |

_Summary: sig=0, below=0 (stat-sig but < threshold), ns=26, missing=0, new_only=0
Bonferroni-corrected α = 0.001923 (26 tests, family α = 0.05)_

</details>
