### PR TITLE
refactor: convert dfsBuildStack to DFSStackBuilder class with reusable state

### DIFF
--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -964,165 +964,145 @@ void dfsFindCycles(ROMol &mol, int atomIdx, int inBondIdx,
   colors[atomIdx] = BLACK_NODE;
 }  // namespace Canon
 
-void dfsBuildStack(ROMol &mol, int atomIdx, int inBondIdx,
-                   std::vector<AtomColors> &colors, const UINT_VECT &ranks,
-                   boost::dynamic_bitset<> &cyclesAvailable, MolStack &molStack,
-                   VECT_INT_VECT &atomRingClosures,
-                   std::vector<INT_LIST> &atomTraversalBondOrder,
-                   const boost::dynamic_bitset<> *bondsInPlay,
-                   const std::vector<std::string> *bondSymbols, bool doRandom) {
-  Atom *atom = mol.getAtomWithIdx(atomIdx);
-  boost::dynamic_bitset<> seenFromHere(mol.getNumAtoms());
+class DFSStackBuilder {
+ public:
+  DFSStackBuilder(ROMol &mol, std::vector<AtomColors> &colors,
+                  const UINT_VECT &ranks,
+                  boost::dynamic_bitset<> &cyclesAvailable, MolStack &molStack,
+                  VECT_INT_VECT &atomRingClosures,
+                  std::vector<INT_LIST> &atomTraversalBondOrder,
+                  const boost::dynamic_bitset<> *bondsInPlay,
+                  const std::vector<std::string> *bondSymbols, bool doRandom)
+      : d_mol(mol),
+        d_colors(colors),
+        d_ranks(ranks),
+        d_cyclesAvailable(cyclesAvailable),
+        d_molStack(molStack),
+        d_atomRingClosures(atomRingClosures),
+        d_atomTraversalBondOrder(atomTraversalBondOrder),
+        d_bondsInPlay(bondsInPlay),
+        d_bondSymbols(bondSymbols),
+        d_doRandom(doRandom),
+        d_seenFromHere(mol.getNumAtoms()) {}
 
-  seenFromHere.set(atomIdx);
-  molStack.push_back(MolStackElem(atom));
-  colors[atomIdx] = GREY_NODE;
+  void build(int atomIdx, int inBondIdx) {
+    Atom *atom = d_mol.getAtomWithIdx(atomIdx);
+    d_seenFromHere.reset();
+    d_seenFromHere.set(atomIdx);
+    d_molStack.push_back(MolStackElem(atom));
+    d_colors[atomIdx] = GREY_NODE;
 
-  INT_LIST travList;
-  if (inBondIdx >= 0) {
-    travList.push_back(inBondIdx);
-  }
+    INT_LIST travList;
+    if (inBondIdx >= 0) {
+      travList.push_back(inBondIdx);
+    }
 
-  // ---------------------
-  //
-  //  Add any ring closures
-  //
-  // ---------------------
-  if (!atomRingClosures[atomIdx].empty()) {
-    std::vector<unsigned int> ringsClosed;
-    for (auto bIdx : atomRingClosures[atomIdx]) {
-      travList.push_back(bIdx);
-      Bond *bond = mol.getBondWithIdx(bIdx);
-      seenFromHere.set(bond->getOtherAtomIdx(atomIdx));
-      unsigned int ringIdx = std::numeric_limits<unsigned int>::max();
-      if (bond->getPropIfPresent(common_properties::_TraversalRingClosureBond,
-                                 ringIdx)) {
-        // this is end of the ring closure
-        // we can just pull the ring index from the bond itself:
-        molStack.push_back(MolStackElem(bond, atomIdx));
-        molStack.push_back(MolStackElem(ringIdx));
-        // don't make the ring digit immediately available again: we don't want
-        // to have the same
-        // ring digit opening and closing rings on an atom.
-        ringsClosed.push_back(ringIdx - 1);
-      } else {
-        // this is the beginning of the ring closure, we need to come up with a
-        // ring index:
-        auto lowestRingIdx = cyclesAvailable.find_first();
-        if (lowestRingIdx == boost::dynamic_bitset<>::npos) {
-          throw ValueErrorException(
-              "Too many rings open at once. SMILES cannot be generated.");
+    if (!d_atomRingClosures[atomIdx].empty()) {
+      d_ringsClosed.clear();
+      for (auto bIdx : d_atomRingClosures[atomIdx]) {
+        travList.push_back(bIdx);
+        Bond *bond = d_mol.getBondWithIdx(bIdx);
+        d_seenFromHere.set(bond->getOtherAtomIdx(atomIdx));
+        unsigned int ringIdx = std::numeric_limits<unsigned int>::max();
+        if (bond->getPropIfPresent(common_properties::_TraversalRingClosureBond,
+                                   ringIdx)) {
+          d_molStack.push_back(MolStackElem(bond, atomIdx));
+          d_molStack.push_back(MolStackElem(ringIdx));
+          d_ringsClosed.push_back(ringIdx - 1);
+        } else {
+          auto lowestRingIdx = d_cyclesAvailable.find_first();
+          if (lowestRingIdx == boost::dynamic_bitset<>::npos) {
+            throw ValueErrorException(
+                "Too many rings open at once. SMILES cannot be generated.");
+          }
+          d_cyclesAvailable.set(lowestRingIdx, false);
+          ++lowestRingIdx;
+          bond->setProp(common_properties::_TraversalRingClosureBond,
+                        static_cast<unsigned int>(lowestRingIdx));
+          d_molStack.push_back(MolStackElem(lowestRingIdx));
         }
-        cyclesAvailable.set(lowestRingIdx, false);
-        ++lowestRingIdx;
-        bond->setProp(common_properties::_TraversalRingClosureBond,
-                      static_cast<unsigned int>(lowestRingIdx));
-        molStack.push_back(MolStackElem(lowestRingIdx));
+      }
+      for (auto ringIdx : d_ringsClosed) {
+        d_cyclesAvailable.set(ringIdx);
       }
     }
-    for (auto ringIdx : ringsClosed) {
-      cyclesAvailable.set(ringIdx);
-    }
-  }
 
-  // ---------------------
-  //
-  //  Build the list of possible destinations from here
-  //
-  // ---------------------
-  std::vector<PossibleType> possibles;
-  possibles.reserve(atom->getDegree());
-  for (auto theBond : mol.atomBonds(atom)) {
-    if (bondsInPlay && !(*bondsInPlay)[theBond->getIdx()]) {
-      continue;
-    }
-    if (inBondIdx < 0 ||
-        theBond->getIdx() != static_cast<unsigned int>(inBondIdx)) {
-      int otherIdx = theBond->getOtherAtomIdx(atomIdx);
-      // ---------------------
-      //
-      // This time we skip the ring-closure atoms (we did them
-      // above); we want to traverse first to atoms outside the ring
-      // then to atoms in the ring that haven't already been visited
-      // (non-ring-closure atoms).
-      //
-      // otherwise it's the same ranking logic as above
-      //
-      // ---------------------
-      if (colors[otherIdx] != WHITE_NODE || seenFromHere[otherIdx]) {
-        // ring closure or finished atom... skip it.
+    d_possibles.clear();
+    d_possibles.reserve(atom->getDegree());
+    for (auto theBond : d_mol.atomBonds(atom)) {
+      if (d_bondsInPlay && !(*d_bondsInPlay)[theBond->getIdx()]) {
         continue;
       }
-      auto rank = ranks[otherIdx];
-      if (!doRandom) {
-        if (theBond->getOwningMol().getRingInfo()->numBondRings(
-                theBond->getIdx())) {
-          if (!bondSymbols) {
-            rank += static_cast<int>(MAX_BONDTYPE - theBond->getBondType()) *
-                    MAX_NATOMS * MAX_NATOMS;
-          } else {
-            const std::string &symb = (*bondSymbols)[theBond->getIdx()];
-            std::uint32_t hsh = gboost::hash_range(symb.begin(), symb.end());
-            rank += (hsh % MAX_NATOMS) * MAX_NATOMS * MAX_NATOMS;
-          }
+      if (inBondIdx < 0 ||
+          theBond->getIdx() != static_cast<unsigned int>(inBondIdx)) {
+        int otherIdx = theBond->getOtherAtomIdx(atomIdx);
+        if (d_colors[otherIdx] != WHITE_NODE || d_seenFromHere[otherIdx]) {
+          continue;
         }
-      } else {
-        // randomize the rank
-        rank = getRandomGenerator()();
+        auto rank = d_ranks[otherIdx];
+        if (!d_doRandom) {
+          if (theBond->getOwningMol().getRingInfo()->numBondRings(
+                  theBond->getIdx())) {
+            if (!d_bondSymbols) {
+              rank += static_cast<int>(MAX_BONDTYPE - theBond->getBondType()) *
+                      MAX_NATOMS * MAX_NATOMS;
+            } else {
+              const std::string &symb = (*d_bondSymbols)[theBond->getIdx()];
+              std::uint32_t hsh = gboost::hash_range(symb.begin(), symb.end());
+              rank += (hsh % MAX_NATOMS) * MAX_NATOMS * MAX_NATOMS;
+            }
+          }
+        } else {
+          rank = getRandomGenerator()();
+        }
+        d_possibles.emplace_back(rank, otherIdx, theBond);
       }
-
-      possibles.emplace_back(rank, otherIdx, theBond);
     }
+
+    std::sort(d_possibles.begin(), d_possibles.end(), _possibleCompare);
+
+    auto localPossibles = d_possibles;
+    for (auto possiblesIt = localPossibles.begin();
+         possiblesIt != localPossibles.end(); ++possiblesIt) {
+      int possibleIdx = std::get<1>(*possiblesIt);
+      if (d_colors[possibleIdx] != WHITE_NODE) {
+        continue;
+      }
+      Bond *bond = std::get<2>(*possiblesIt);
+      Atom *otherAtom = d_mol.getAtomWithIdx(possibleIdx);
+      otherAtom->clearProp(common_properties::_TraversalBondIndexOrder);
+      travList.push_back(bond->getIdx());
+      if (possiblesIt + 1 != localPossibles.end()) {
+        d_molStack.push_back(MolStackElem(
+            "(", rdcast<int>(possiblesIt - localPossibles.begin())));
+      }
+      d_molStack.push_back(MolStackElem(bond, atomIdx));
+      build(possibleIdx, bond->getIdx());
+      if (possiblesIt + 1 != localPossibles.end()) {
+        d_molStack.push_back(MolStackElem(
+            ")", rdcast<int>(possiblesIt - localPossibles.begin())));
+      }
+    }
+
+    d_atomTraversalBondOrder[atom->getIdx()] = travList;
+    d_colors[atomIdx] = BLACK_NODE;
   }
 
-  // ---------------------
-  //
-  //  Sort on ranks
-  //
-  // ---------------------
-  std::sort(possibles.begin(), possibles.end(), _possibleCompare);
-  // if (possibles.size())
-  //   std::cerr << " aIdx2: " << atomIdx
-  //             << " first: " << possibles.front()std:std::get<0>() << " "
-  //             << possibles.front()std:std::get<1>() << std::endl;
-
-  // ---------------------
-  //
-  //  Now work the children
-  //
-  // ---------------------
-  for (auto possiblesIt = possibles.begin(); possiblesIt != possibles.end();
-       ++possiblesIt) {
-    int possibleIdx = std::get<1>(*possiblesIt);
-    if (colors[possibleIdx] != WHITE_NODE) {
-      // we're either done or it's a ring-closure, which we already processed...
-      // this test isn't strictly required, because we only added WHITE notes to
-      // the possibles list, but it seems logical to document it
-      continue;
-    }
-    Bond *bond = std::get<2>(*possiblesIt);
-    Atom *otherAtom = mol.getAtomWithIdx(possibleIdx);
-    // ww might have some residual data from earlier calls, clean that up:
-    otherAtom->clearProp(common_properties::_TraversalBondIndexOrder);
-    travList.push_back(bond->getIdx());
-    if (possiblesIt + 1 != possibles.end()) {
-      // we're branching
-      molStack.push_back(
-          MolStackElem("(", rdcast<int>(possiblesIt - possibles.begin())));
-    }
-    molStack.push_back(MolStackElem(bond, atomIdx));
-    dfsBuildStack(mol, possibleIdx, bond->getIdx(), colors, ranks,
-                  cyclesAvailable, molStack, atomRingClosures,
-                  atomTraversalBondOrder, bondsInPlay, bondSymbols, doRandom);
-    if (possiblesIt + 1 != possibles.end()) {
-      molStack.push_back(
-          MolStackElem(")", rdcast<int>(possiblesIt - possibles.begin())));
-    }
-  }
-
-  atomTraversalBondOrder[atom->getIdx()] = travList;
-  colors[atomIdx] = BLACK_NODE;
-}
+ private:
+  ROMol &d_mol;
+  std::vector<AtomColors> &d_colors;
+  const UINT_VECT &d_ranks;
+  boost::dynamic_bitset<> &d_cyclesAvailable;
+  MolStack &d_molStack;
+  VECT_INT_VECT &d_atomRingClosures;
+  std::vector<INT_LIST> &d_atomTraversalBondOrder;
+  const boost::dynamic_bitset<> *d_bondsInPlay;
+  const std::vector<std::string> *d_bondSymbols;
+  bool d_doRandom;
+  boost::dynamic_bitset<> d_seenFromHere;
+  std::vector<unsigned int> d_ringsClosed;
+  std::vector<PossibleType> d_possibles;
+};
 
 void canonicalDFSTraversal(ROMol &mol, int atomIdx, int inBondIdx,
                            std::vector<AtomColors> &colors,
@@ -1149,9 +1129,10 @@ void canonicalDFSTraversal(ROMol &mol, int atomIdx, int inBondIdx,
 
   boost::dynamic_bitset<> cyclesAvailable(MAX_CYCLES);
   cyclesAvailable.set();
-  dfsBuildStack(mol, atomIdx, inBondIdx, colors, ranks, cyclesAvailable,
-                molStack, atomRingClosures, atomTraversalBondOrder, bondsInPlay,
-                bondSymbols, doRandom);
+  DFSStackBuilder builder(mol, colors, ranks, cyclesAvailable, molStack,
+                          atomRingClosures, atomTraversalBondOrder, bondsInPlay,
+                          bondSymbols, doRandom);
+  builder.build(atomIdx, inBondIdx);
 }
 
 void clearBondDirs(ROMol &mol, Bond *refBond, const Atom *fromAtom,


### PR DESCRIPTION
*summary by opus-4.6 via opencode:*

Refactor `dfsBuildStack` from a free function into a `DFSStackBuilder` class, allowing reuse of temporary vectors across calls to avoid repeated heap allocations.

**Benchmark (16 rounds × 800 samples, interleaved, Bonferroni-corrected α=0.002):**
No significant results (0/26).

<details>
<summary>Benchmark Results (vs master)</summary>

| Benchmark | Old (mean±sd) | New (mean±sd) | Δ% | CV | Speed | Sig(p) |
|:---|---:|---:|---:|---:|:---|:---|
| bench_common::nth_random | 1.38 ns ± 0.152 ns | 1.43 ns ± 0.139 ns | +3.6% | 11.0% | 1.04× slower | ns p=0.345 |
| Chirality::findPotentialStereo | 1.57 ms ± 84.5 us | 1.58 ms ± 80.3 us | +0.9% | 5.4% | 1.01× slower | ns p=0.626 |
| CIPLabeler::assignCIPLabels | 580 ms ± 37.4 ms | 572 ms ± 39.2 ms | -1.3% | 6.9% | 1.01× faster | ns p=0.585 |
| Descriptors::calcNumBridgeheadAtoms | 4.41 us ± 491 ns | 4.36 us ± 533 ns | -1.2% | 12.2% | 1.01× faster | ns p=0.78 |
| Descriptors::calcNumSpiroAtoms | 4.74 us ± 363 ns | 4.9 us ± 589 ns | +3.3% | 12.0% | 1.03× slower | ns p=0.372 |
| InchiToInchiKey | 50 us ± 4.76 us | 49.1 us ± 4.17 us | -1.8% | 9.5% | 1.02× faster | ns p=0.564 |
| InchiToMol | 10.5 ms ± 303 us | 10.5 ms ± 297 us | -0.3% | 2.9% | 1.00× faster | ns p=0.776 |
| memory pressure test | 17.5 us ± 3.84 us | 17.2 us ± 3.79 us | -1.7% | 22.0% | 1.02× faster | ns p=0.831 |
| MolOps::addHs | 790 us ± 38.9 us | 778 us ± 43.7 us | -1.6% | 5.6% | 1.02× faster | ns p=0.405 |
| MolOps::assignStereochemistry legacy=false | 1.92 ms ± 59.6 us | 1.94 ms ± 90 us | +0.8% | 4.7% | 1.01× slower | ns p=0.557 |
| MolOps::assignStereochemistry legacy=true | 1.13 ms ± 60.4 us | 1.12 ms ± 63.4 us | -1.0% | 5.7% | 1.01× faster | ns p=0.616 |
| MolOps::FindSSR | 369 us ± 20.3 us | 383 us ± 17.2 us | +3.9% | 5.5% | 1.04× slower | ns p=0.0408 |
| MolOps::getMolFrags | 2.26 ms ± 89 us | 2.3 ms ± 126 us | +1.7% | 5.5% | 1.02× slower | ns p=0.328 |
| MolPickler::molFromPickle | 297 us ± 16.9 us | 297 us ± 16.4 us | +0.2% | 5.7% | 1.00× slower | ns p=0.905 |
| MolPickler::pickleMol | 278 us ± 18.5 us | 276 us ± 15.2 us | -0.6% | 6.7% | 1.01× faster | ns p=0.779 |
| MolToCXSmiles | 2.55 ms ± 109 us | 2.57 ms ± 162 us | +0.7% | 6.3% | 1.01× slower | ns p=0.736 |
| MolToInchi | 6.09 ms ± 154 us | 6.01 ms ± 146 us | -1.3% | 2.5% | 1.01× faster | ns p=0.145 |
| MolToSmiles | 1.99 ms ± 87.9 us | 1.97 ms ± 122 us | -0.6% | 6.2% | 1.01× faster | ns p=0.743 |
| MorganFingerprints::getFingerprint | 626 us ± 16.1 us | 615 us ± 22.4 us | -1.8% | 3.6% | 1.02× faster | ns p=0.118 |
| ROMol copy constructor | 155 us ± 9.8 us | 145 us ± 9.35 us | -6.4% | 6.5% | 1.07× faster | ns p=0.00624 |
| ROMol destructor | 62.4 us ± 3.75 us | 63.8 us ± 3.95 us | +2.2% | 6.2% | 1.02× slower | ns p=0.318 |
| ROMol::getNumHeavyAtoms | 351 ns ± 31.5 ns | 347 ns ± 30.3 ns | -1.0% | 9.0% | 1.01× faster | ns p=0.749 |
| ROMol::GetSubstructMatch | 112 us ± 10.3 us | 112 us ± 8.48 us | -0.5% | 9.2% | 1.00× faster | ns p=0.872 |
| ROMol::GetSubstructMatch patty | 3.61 ms ± 72.3 us | 3.59 ms ± 95.7 us | -0.4% | 2.7% | 1.00× faster | ns p=0.631 |
| ROMol::GetSubstructMatch RLewis | 22 ms ± 447 us | 21.9 ms ± 443 us | -0.6% | 2.0% | 1.01× faster | ns p=0.437 |
| SmilesToMol | 2.96 ms ± 111 us | 2.95 ms ± 121 us | -0.3% | 4.1% | 1.00× faster | ns p=0.847 |

_Summary: sig=0, below=0 (stat-sig but < threshold), ns=26, missing=0, new_only=0
Bonferroni-corrected α = 0.001923 (26 tests, family α = 0.05)_

</details>
