### PR TITLE
perf: use std::deque instead of std::list for ReactionRunner atomStack

### DIFF
--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -36,6 +36,7 @@
 #include <GraphMol/Substruct/SubstructMatch.h>
 #include <GraphMol/QueryOps.h>
 #include <boost/dynamic_bitset.hpp>
+#include <deque>
 #include <map>
 #include <algorithm>
 #include <GraphMol/ChemTransforms/ChemTransforms.h>
@@ -943,7 +944,7 @@ void addReactantNeighborsToProduct(
     boost::dynamic_bitset<> &visitedAtoms,
     std::vector<const Atom *> &chiralAtomsToCheck,
     ReactantProductAtomMapping *mapping, unsigned int reactantId) {
-  std::list<const Atom *> atomStack;
+  std::deque<const Atom *> atomStack;
   atomStack.push_back(&reactantAtom);
 
   // std::cerr << "-------------------" << std::endl;


### PR DESCRIPTION
*summary by opus-4.6 via opencode:*

Replace `std::list<ReactantProductAtomMapping::ReactantAtomPair>` with `std::deque` for the atom stack in ReactionRunner. Deque provides better cache locality for the push/pop pattern used here.

Reactions are not covered by the current benchmark suite.

**Benchmark (16 rounds × 800 samples, interleaved, Bonferroni-corrected α=0.002):**
No significant results (0/26).

<details>
<summary>Benchmark Results (vs master)</summary>

| Benchmark | Old (mean±sd) | New (mean±sd) | Δ% | CV | Speed | Sig(p) |
|:---|---:|---:|---:|---:|:---|:---|
| bench_common::nth_random | 1.38 ns ± 0.134 ns | 1.38 ns ± 0.131 ns | +0.0% | 9.7% | 1.00× slower | ns p=0.989 |
| Chirality::findPotentialStereo | 1.6 ms ± 77.4 us | 1.6 ms ± 90.4 us | +0.0% | 5.7% | 1.00× slower | ns p=0.979 |
| CIPLabeler::assignCIPLabels | 587 ms ± 40.6 ms | 577 ms ± 36.1 ms | -1.7% | 6.9% | 1.02× faster | ns p=0.455 |
| Descriptors::calcNumBridgeheadAtoms | 4.15 us ± 302 ns | 4.27 us ± 346 ns | +2.8% | 8.1% | 1.03× slower | ns p=0.327 |
| Descriptors::calcNumSpiroAtoms | 5.11 us ± 644 ns | 5.09 us ± 499 ns | -0.4% | 12.6% | 1.00× faster | ns p=0.928 |
| InchiToInchiKey | 49 us ± 3.79 us | 50.3 us ± 4.45 us | +2.7% | 8.9% | 1.03× slower | ns p=0.369 |
| InchiToMol | 10.5 ms ± 272 us | 10.5 ms ± 244 us | +0.0% | 2.6% | 1.00× slower | ns p=0.985 |
| memory pressure test | 17.3 us ± 2.99 us | 16.6 us ± 2.94 us | -4.2% | 17.8% | 1.04× faster | ns p=0.489 |
| MolOps::addHs | 802 us ± 28.5 us | 770 us ± 59 us | -4.0% | 7.7% | 1.04× faster | ns p=0.0613 |
| MolOps::assignStereochemistry legacy=false | 1.93 ms ± 71.3 us | 1.93 ms ± 64.3 us | -0.0% | 3.7% | 1.00× faster | ns p=0.969 |
| MolOps::assignStereochemistry legacy=true | 1.13 ms ± 44 us | 1.15 ms ± 42 us | +1.9% | 3.9% | 1.02× slower | ns p=0.17 |
| MolOps::FindSSR | 387 us ± 24.2 us | 376 us ± 22.6 us | -3.0% | 6.2% | 1.03× faster | ns p=0.172 |
| MolOps::getMolFrags | 2.3 ms ± 92.4 us | 2.28 ms ± 100 us | -1.0% | 4.4% | 1.01× faster | ns p=0.523 |
| MolPickler::molFromPickle | 299 us ± 19.5 us | 296 us ± 15.1 us | -0.8% | 6.5% | 1.01× faster | ns p=0.686 |
| MolPickler::pickleMol | 278 us ± 16.2 us | 282 us ± 18.7 us | +1.7% | 6.6% | 1.02× slower | ns p=0.443 |
| MolToCXSmiles | 2.59 ms ± 126 us | 2.59 ms ± 120 us | -0.1% | 4.9% | 1.00× faster | ns p=0.949 |
| MolToInchi | 6.1 ms ± 141 us | 6.12 ms ± 126 us | +0.4% | 2.3% | 1.00× slower | ns p=0.618 |
| MolToSmiles | 2 ms ± 104 us | 1.98 ms ± 84.3 us | -0.8% | 5.2% | 1.01× faster | ns p=0.62 |
| MorganFingerprints::getFingerprint | 618 us ± 29.8 us | 623 us ± 26.8 us | +0.8% | 4.8% | 1.01× slower | ns p=0.622 |
| ROMol copy constructor | 147 us ± 12.9 us | 150 us ± 12.4 us | +2.3% | 8.8% | 1.02× slower | ns p=0.455 |
| ROMol destructor | 62.7 us ± 4.28 us | 63.2 us ± 3.15 us | +0.8% | 6.8% | 1.01× slower | ns p=0.717 |
| ROMol::getNumHeavyAtoms | 351 ns ± 27.7 ns | 365 ns ± 28.7 ns | +4.0% | 7.9% | 1.04× slower | ns p=0.168 |
| ROMol::GetSubstructMatch | 115 us ± 8.62 us | 113 us ± 7.59 us | -1.4% | 7.5% | 1.01× faster | ns p=0.582 |
| ROMol::GetSubstructMatch patty | 3.64 ms ± 93.9 us | 3.64 ms ± 75.1 us | +0.1% | 2.6% | 1.00× slower | ns p=0.95 |
| ROMol::GetSubstructMatch RLewis | 22.1 ms ± 403 us | 22.2 ms ± 413 us | +0.6% | 1.9% | 1.01× slower | ns p=0.382 |
| SmilesToMol | 2.98 ms ± 105 us | 2.96 ms ± 88.9 us | -0.7% | 3.5% | 1.01× faster | ns p=0.534 |

_Summary: sig=0, below=0 (stat-sig but < threshold), ns=26, missing=0, new_only=0
Bonferroni-corrected α = 0.001923 (26 tests, family α = 0.05)_

</details>
