### PR TITLE
perf: intern Dict keys as uint16_t, make common_properties DictKey constants

### DIFF
--- a/Code/GraphMol/ChemReactions/PreprocessRxn.h
+++ b/Code/GraphMol/ChemReactions/PreprocessRxn.h
@@ -42,24 +42,24 @@ namespace RDKit {
 
 RDKIT_CHEMREACTIONS_EXPORT bool preprocessReaction(
     ChemicalReaction &rxn,
-    const std::string_view &propName = common_properties::molFileValue);
+    const std::string_view &propName = kWellKnownKeys[common_properties::molFileValue]);
 
 RDKIT_CHEMREACTIONS_EXPORT bool preprocessReaction(
     ChemicalReaction &rxn, unsigned int &numWarnings, unsigned int &numErrors,
     std::vector<std::vector<std::pair<unsigned int, std::string>>>
         &reactantLabels,
-    const std::string_view &propName = common_properties::molFileValue);
+    const std::string_view &propName = kWellKnownKeys[common_properties::molFileValue]);
 
 RDKIT_CHEMREACTIONS_EXPORT bool preprocessReaction(
     ChemicalReaction &rxn, const std::map<std::string, ROMOL_SPTR> &queries,
-    const std::string_view &propName = common_properties::molFileValue);
+    const std::string_view &propName = kWellKnownKeys[common_properties::molFileValue]);
 
 RDKIT_CHEMREACTIONS_EXPORT bool preprocessReaction(
     ChemicalReaction &rxn, unsigned int &numWarnings, unsigned int &numErrors,
     std::vector<std::vector<std::pair<unsigned int, std::string>>>
         &reactantLabels,
     const std::map<std::string, ROMOL_SPTR> &queries,
-    const std::string_view &propName = common_properties::molFileValue);
+    const std::string_view &propName = kWellKnownKeys[common_properties::molFileValue]);
 }  // namespace RDKit
 
 #endif

--- a/Code/GraphMol/ChemReactions/ReactionUtils.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionUtils.cpp
@@ -141,7 +141,7 @@ bool hasReactionAtomMapping(const ChemicalReaction &rxn) {
   for (; begin != end; ++begin) {
     const ROMol &reactant = *begin->get();
     if (MolOps::getNumAtomsWithDistinctProperty(
-            reactant, common_properties::molAtomMapNumber)) {
+            reactant, keyToString(common_properties::molAtomMapNumber))) {
       return true;
     }
   }
@@ -150,7 +150,7 @@ bool hasReactionAtomMapping(const ChemicalReaction &rxn) {
   for (; begin != end; ++begin) {
     const ROMol &reactant = *begin->get();
     if (MolOps::getNumAtomsWithDistinctProperty(
-            reactant, common_properties::molAtomMapNumber)) {
+            reactant, keyToString(common_properties::molAtomMapNumber))) {
       return true;
     }
   }
@@ -159,7 +159,7 @@ bool hasReactionAtomMapping(const ChemicalReaction &rxn) {
 
 bool isReactionTemplateMoleculeAgent(const ROMol &mol, double agentThreshold) {
   unsigned numMappedAtoms = MolOps::getNumAtomsWithDistinctProperty(
-      mol, common_properties::molAtomMapNumber);
+      mol, keyToString(common_properties::molAtomMapNumber));
   unsigned numAtoms = mol.getNumHeavyAtoms();
   return !(numAtoms > 0u && static_cast<double>(numMappedAtoms) /
                                     static_cast<double>(numAtoms) >=

--- a/Code/GraphMol/ChemReactions/SanitizeRxn.cpp
+++ b/Code/GraphMol/ChemReactions/SanitizeRxn.cpp
@@ -40,7 +40,7 @@ namespace RxnOps {
 // molFileRLabel ==> unsigned int
 namespace {
 template <class T>
-T getMaxProp(ChemicalReaction &rxn, const std::string_view &prop) {
+T getMaxProp(ChemicalReaction &rxn, DictKey prop) {
   T max_atom = (T)0;
   for (auto it = rxn.beginReactantTemplates(); it != rxn.endReactantTemplates();
        ++it) {

--- a/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
@@ -1246,7 +1246,7 @@ One unrecognized group type in a comma-separated list makes the whole thing fail
   python::def(
       "PreprocessReaction", RDKit::PreprocessReaction,
       (python::arg("reaction"), python::arg("queries") = python::dict(),
-       python::arg("propName") = RDKit::common_properties::molFileValue),
+       python::arg("propName") = RDKit::kWellKnownKeys[RDKit::common_properties::molFileValue]),
       docString.c_str());
 
   python::enum_<RDKit::RxnOps::SanitizeRxnFlags>("SanitizeFlags")

--- a/Code/GraphMol/Descriptors/MolSurf.cpp
+++ b/Code/GraphMol/Descriptors/MolSurf.cpp
@@ -105,9 +105,9 @@ double getTPSAAtomContribs(const ROMol &mol, std::vector<double> &Vi,
   TEST_ASSERT(Vi.size() >= mol.getNumAtoms());
   double res = 0;
   std::string pname =
-      (boost::format("%s-%s") % common_properties::_tpsa % includeSandP).str();
+      (boost::format("%s-%s") % keyToString(common_properties::_tpsa) % includeSandP).str();
   std::string contribsName =
-      (boost::format("%s-%s") % common_properties::_tpsaAtomContribs %
+      (boost::format("%s-%s") % keyToString(common_properties::_tpsaAtomContribs) %
        includeSandP)
           .str();
   if (!force && mol.hasProp(contribsName)) {
@@ -346,7 +346,7 @@ double getTPSAAtomContribs(const ROMol &mol, std::vector<double> &Vi,
 }
 double calcTPSA(const ROMol &mol, bool force, bool includeSandP) {
   std::string pname =
-      (boost::format("%s-%s") % common_properties::_tpsa % includeSandP).str();
+      (boost::format("%s-%s") % keyToString(common_properties::_tpsa) % includeSandP).str();
   if (!force && mol.hasProp(pname)) {
     double res;
     mol.getProp(pname, res);

--- a/Code/GraphMol/FileParsers/MaeWriter.cpp
+++ b/Code/GraphMol/FileParsers/MaeWriter.cpp
@@ -139,7 +139,7 @@ void copyProperties(
 
   for (const auto &prop : origin.getDict()) {
     // Skip the property holding the names of the computed properties
-    if (prop.key == detail::computedPropName) {
+    if (prop.key == keyToString(detail::computedPropName)) {
       continue;
     }
 
@@ -164,7 +164,7 @@ void copyProperties(
       case RDTypeTag::IntTag:
       case RDTypeTag::UnsignedIntTag: {
         auto propName = prop.key;
-        if (prop.key == common_properties::_MolFileRLabel) {
+        if (prop.key == keyToString(common_properties::_MolFileRLabel)) {
           propName = MAE_RGROUP_LABEL;
         } else if (!std::regex_match(prop.key, MMCT_PROP_REGEX)) {
           propName.insert(0, "i_rdkit_");

--- a/Code/GraphMol/FileParsers/MaeWriter.cpp
+++ b/Code/GraphMol/FileParsers/MaeWriter.cpp
@@ -137,7 +137,7 @@ void copyProperties(
   // since we don't want to export these.
   origin.clearComputedProps();
 
-  for (const auto &prop : origin.getDict()) {
+  for (const auto &prop : origin.getDict().getData()) {
     // Skip the property holding the names of the computed properties
     if (prop.key == keyToString(detail::computedPropName)) {
       continue;

--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -1315,7 +1315,7 @@ std::string outputMolToMolBlock(const RWMol &tmol, int confId,
       if (conf->is3D()) {
         ss << "3D";
       } else {
-        ss << common_properties::TWOD;
+        ss << keyToString(common_properties::TWOD);
       }
     }
     res += ss.str();

--- a/Code/GraphMol/FileParsers/SDWriter.cpp
+++ b/Code/GraphMol/FileParsers/SDWriter.cpp
@@ -144,10 +144,10 @@ void _MolToSDStream(std::ostream *dp_ostream, const ROMol &mol, int confId,
     STR_VECT_CI pi;
     for (pi = properties.begin(); pi != properties.end(); pi++) {
       // ignore any of the following properties
-      if (((*pi) == RDKit::detail::computedPropName) ||
-          ((*pi) == common_properties::_Name) || ((*pi) == "_MolFileInfo") ||
+      if (((*pi) == keyToString(RDKit::detail::computedPropName)) ||
+          ((*pi) == keyToString(common_properties::_Name)) || ((*pi) == "_MolFileInfo") ||
           ((*pi) == "_MolFileComments") ||
-          ((*pi) == common_properties::_MolFileChiralFlag)) {
+          ((*pi) == keyToString(common_properties::_MolFileChiralFlag))) {
         continue;
       }
 

--- a/Code/GraphMol/FileParsers/TDTMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/TDTMolSupplier.cpp
@@ -202,7 +202,7 @@ std::unique_ptr<RWMol> TDTMolSupplier::parseMol(std::string inLine) {
       boost::trim_if(propName, boost::is_any_of(" \t"));
       startP = endP + 1;
 
-      if (propName == common_properties::TWOD && d_params.confId2D >= 0) {
+      if (propName == keyToString(common_properties::TWOD) && d_params.confId2D >= 0) {
         std::string rest = inLine.substr(startP, inLine.size() - startP);
         std::vector<double> coords;
         TDTParseUtils::ParseNumberList(rest, coords, dp_inStream);

--- a/Code/GraphMol/FileParsers/TDTWriter.cpp
+++ b/Code/GraphMol/FileParsers/TDTWriter.cpp
@@ -144,10 +144,10 @@ void TDTWriter::write(const ROMol &mol, int confId) {
     STR_VECT_CI pi;
     for (pi = properties.begin(); pi != properties.end(); pi++) {
       // ignore any of the following properties
-      if (((*pi) == RDKit::detail::computedPropName) ||
-          ((*pi) == common_properties::_Name) || ((*pi) == "_MolFileInfo") ||
+      if (((*pi) == keyToString(RDKit::detail::computedPropName)) ||
+          ((*pi) == keyToString(common_properties::_Name)) || ((*pi) == "_MolFileInfo") ||
           ((*pi) == "_MolFileComments") ||
-          ((*pi) == common_properties::_MolFileChiralFlag)) {
+          ((*pi) == keyToString(common_properties::_MolFileChiralFlag))) {
         continue;
       }
 

--- a/Code/GraphMol/FileParsers/TplFileParser.cpp
+++ b/Code/GraphMol/FileParsers/TplFileParser.cpp
@@ -125,7 +125,7 @@ Conformer *ParseConfData(std::istream &inStream, unsigned int &line, RWMol *mol,
     throw FileParseException(errout.str());
   }
   std::ostringstream propName;
-  propName << "Conf_" << mol->getNumConformers() << common_properties::_Name;
+  propName << "Conf_" << mol->getNumConformers() << keyToString(common_properties::_Name);
   mol->setProp(propName.str(),
                boost::trim_copy(tempStr.substr(4, tempStr.size() - 4)));
 

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -6204,8 +6204,8 @@ void check_roundtripped_properties(RDProps &original, RDProps &roundtrip) {
   REQUIRE(std::includes(roundtripPropNames.begin(), roundtripPropNames.end(),
                         originalPropNames.begin(), originalPropNames.end()));
 
-  for (const auto &o : original.getDict()) {
-    if (o.key == detail::computedPropName) {
+  for (const auto &o : original.getDict().getData()) {
+    if (o.key == keyToString(detail::computedPropName)) {
       continue;
     }
 

--- a/Code/GraphMol/FragCatalog/FragCatalogEntry.h
+++ b/Code/GraphMol/FragCatalog/FragCatalogEntry.h
@@ -66,26 +66,38 @@ class RDKIT_FRAGCATALOG_EXPORT FragCatalogEntry
   // REVIEW: this should be removed?
   std::string getSmarts() { return ""; }
 
-  // FUnctions on the property dictionary
   template <typename T>
   void setProp(const std::string_view &key, T &val) const {
+    dp_props->setVal(key, val);
+  }
+  template <typename T>
+  void setProp(DictKey key, T &val) const {
     dp_props->setVal(key, val);
   }
 
   void setProp(const std::string_view &key, int val) const {
     dp_props->setVal(key, val);
   }
+  void setProp(DictKey key, int val) const { dp_props->setVal(key, val); }
 
   void setProp(const std::string_view &key, float val) const {
     dp_props->setVal(key, val);
   }
+  void setProp(DictKey key, float val) const { dp_props->setVal(key, val); }
 
   void setProp(const std::string_view &key, std::string &val) const {
+    dp_props->setVal(key, val);
+  }
+  void setProp(DictKey key, std::string &val) const {
     dp_props->setVal(key, val);
   }
 
   template <typename T>
   void getProp(const std::string_view &key, T &res) const {
+    dp_props->getVal(key, res);
+  }
+  template <typename T>
+  void getProp(DictKey key, T &res) const {
     dp_props->getVal(key, res);
   }
 
@@ -95,8 +107,15 @@ class RDKIT_FRAGCATALOG_EXPORT FragCatalogEntry
     }
     return dp_props->hasVal(key);
   }
+  bool hasProp(DictKey key) const {
+    if (!dp_props) {
+      return false;
+    }
+    return dp_props->hasVal(key);
+  }
 
   void clearProp(const std::string_view &key) const { dp_props->clearVal(key); }
+  void clearProp(DictKey key) const { dp_props->clearVal(key); }
 
   void toStream(std::ostream &ss) const override;
   std::string Serialize() const override;

--- a/Code/GraphMol/MolPickler.cpp
+++ b/Code/GraphMol/MolPickler.cpp
@@ -168,26 +168,26 @@ class PropTracker {
   // the properties themselves are stored as std::int8_t
   static constexpr std::array<std::pair<std::string_view, std::uint16_t>, 5>
       explicitBondProps{{
-          {RDKit::common_properties::_MolFileBondType, 0x1},
-          {RDKit::common_properties::_MolFileBondStereo, 0x2},
-          {RDKit::common_properties::_MolFileBondCfg, 0x4},
-          {RDKit::common_properties::_MolFileBondQuery, 0x8},
-          {RDKit::common_properties::molStereoCare, 0x10},
+          {kWellKnownKeys[common_properties::_MolFileBondType], 0x1},
+          {kWellKnownKeys[common_properties::_MolFileBondStereo], 0x2},
+          {kWellKnownKeys[common_properties::_MolFileBondCfg], 0x4},
+          {kWellKnownKeys[common_properties::_MolFileBondQuery], 0x8},
+          {kWellKnownKeys[common_properties::molStereoCare], 0x10},
       }};
   // this is stored as bitflags in a byte, so don't exceed 8 entries or we need
   // to update the pickle format.
   // the properties themselves are stored as std::int16_t
   static constexpr std::array<std::pair<std::string_view, std::uint16_t>, 4>
       explicitAtomProps{{
-          {common_properties::molStereoCare, 0x1},
-          {common_properties::molParity, 0x2},
-          {common_properties::molInversionFlag, 0x4},
-          {common_properties::_ChiralityPossible, 0x8},
+          {kWellKnownKeys[common_properties::molStereoCare], 0x1},
+          {kWellKnownKeys[common_properties::molParity], 0x2},
+          {kWellKnownKeys[common_properties::molInversionFlag], 0x4},
+          {kWellKnownKeys[common_properties::_ChiralityPossible], 0x8},
 
       }};
   static constexpr std::array<std::string_view, 2> ignoreAtomProps{
-      common_properties::molAtomMapNumber,
-      common_properties::dummyLabel,
+      kWellKnownKeys[common_properties::molAtomMapNumber],
+      kWellKnownKeys[common_properties::dummyLabel],
   };
   std::unordered_set<std::string_view> ignoreBondProps;
   PropTracker() {

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -2028,10 +2028,10 @@ std::string get_coords_block(const ROMol &mol,
 std::string get_atom_props_block(const ROMol &mol,
                                  const std::vector<unsigned int> &atomOrder) {
   constexpr std::array<std::string_view, 7> skip = {
-      common_properties::atomLabel,       common_properties::molFileValue,
-      common_properties::molParity,       common_properties::molAtomMapNumber,
-      common_properties::molStereoCare,   common_properties::molRxnExactChange,
-      common_properties::molInversionFlag};
+      kWellKnownKeys[common_properties::atomLabel],       kWellKnownKeys[common_properties::molFileValue],
+      kWellKnownKeys[common_properties::molParity],       kWellKnownKeys[common_properties::molAtomMapNumber],
+      kWellKnownKeys[common_properties::molStereoCare],   kWellKnownKeys[common_properties::molRxnExactChange],
+      kWellKnownKeys[common_properties::molInversionFlag]};
   std::string res = "";
   unsigned int which = 0;
   for (auto idx : atomOrder) {
@@ -2550,7 +2550,7 @@ std::string getCXExtensions(const ROMol &mol, std::uint32_t flags) {
       res += ",";
     }
     res += "$_AV:" +
-           get_value_block(mol, atomOrder, common_properties::molFileValue) +
+           get_value_block(mol, atomOrder, keyToString(common_properties::molFileValue)) +
            "$";
   }
   auto radblock = get_radical_block(mol, atomOrder);

--- a/Code/GraphMol/Subset.cpp
+++ b/Code/GraphMol/Subset.cpp
@@ -19,7 +19,7 @@ namespace {
 inline void copyComputedProps(const ROMol &src, ROMol &dst) {
   dst.updateProps(src);
   for (auto &v : dst.getPropList(true, false)) {
-    if (v != RDKit::detail::computedPropName) {
+    if (v != keyToString(RDKit::detail::computedPropName)) {
       dst.clearProp(v);
     }
   }

--- a/Code/GraphMol/Wrap/props.hpp
+++ b/Code/GraphMol/Wrap/props.hpp
@@ -99,10 +99,11 @@ boost::python::dict GetPropsAsDict(const T &obj, bool includePrivate,
                                    bool includeComputed,
                                    bool autoConvertStrings = true) {
   boost::python::dict dict;
-  const auto &rd_dict = obj.getDict();
+  auto &rd_dict = obj.getDict();
+  auto data = rd_dict.getData();
 
   STR_VECT keys = obj.getPropList(includePrivate, includeComputed);
-  for (const auto &rdvalue : rd_dict) {
+  for (auto &rdvalue : data) {
     if (std::find(keys.begin(), keys.end(), rdvalue.key) == keys.end()) {
       continue;
     }
@@ -241,8 +242,8 @@ PyObject *GetPyProp(const RDOb *obj, const std::string &key, bool autoConvert) {
       return nullptr;
     }
   } else {
-    const auto &rd_dict = obj->getDict();
-    for (const auto &rdvalue : rd_dict) {
+    const auto &data = obj->getDict().getData();
+    for (auto &rdvalue : data) {
       if (rdvalue.key == key) {
         try {
           const auto tag = rdvalue.val.getTag();

--- a/Code/GraphMol/catch_pickles.cpp
+++ b/Code/GraphMol/catch_pickles.cpp
@@ -98,8 +98,8 @@ M  END)CTAB"_ctab;
 
     CHECK(pkl.size() > basepkl.size());
     // make sure the property names aren't in the pickle
-    CHECK(pkl.find(common_properties::_MolFileBondType) == std::string::npos);
-    CHECK(pkl.find(common_properties::_MolFileBondCfg) == std::string::npos);
+    CHECK(pkl.find(keyToString(common_properties::_MolFileBondType)) == std::string::npos);
+    CHECK(pkl.find(keyToString(common_properties::_MolFileBondCfg)) == std::string::npos);
     // std::cerr << "!!!! " << pkl.size() << " " << basepkl.size() << std::endl;
 
     RWMol mol2(pkl);
@@ -203,8 +203,8 @@ M  END
     MolPickler::pickleMol(*mol, pkl);
 
     // make sure the property names aren't in the pickle
-    CHECK(pkl.find(common_properties::_MolFileBondAttach) == std::string::npos);
-    CHECK(pkl.find(common_properties::_MolFileBondEndPts) == std::string::npos);
+    CHECK(pkl.find(keyToString(common_properties::_MolFileBondAttach)) == std::string::npos);
+    CHECK(pkl.find(keyToString(common_properties::_MolFileBondEndPts)) == std::string::npos);
     // std::cerr << "!!!! " << pkl.size() << " " << basepkl.size() << std::endl;
 
     RWMol mol2(pkl);

--- a/Code/JavaWrappers/Dict.i
+++ b/Code/JavaWrappers/Dict.i
@@ -39,12 +39,17 @@
 %include "std_string_view.i"
 
 %ignore RDKit::Dict::Pair;
+%ignore RDKit::Dict::InternalPair;
+%ignore RDKit::Dict::InternalDataType;
+%ignore RDKit::Dict::getInternalData;
 %ignore RDKit::PairHolder;
-%ignore RDKit::Dict::extend;
 %ignore RDKit::Dict::getRDValue;
-%ignore RDKit::Dict::begin;
-%ignore RDKit::Dict::end;
-%ignore RDKit::Dict::const_iterator;
+%ignore RDKit::DictKeyIntern;
+%ignore RDKit::internKey;
+%ignore RDKit::keyToString;
+%ignore RDKit::common_properties;
+%ignore RDKit::detail::computedPropName;
+%include <RDGeneral/DictKeyIntern.h>
 %include <RDGeneral/Dict.h>
 
 

--- a/Code/RDGeneral/Dict.h
+++ b/Code/RDGeneral/Dict.h
@@ -21,6 +21,7 @@
 #include <vector>
 #include "RDValue.h"
 #include "Exceptions.h"
+#include "DictKeyIntern.h"
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/lexical_cast.hpp>
 #include <RDGeneral/BoostEndInclude.h>
@@ -35,6 +36,16 @@ typedef std::vector<std::string> STR_VECT;
 //!
 class RDKIT_RDGENERAL_EXPORT Dict {
  public:
+  struct InternalPair {
+    DictKey key;
+    RDValue val;
+
+    InternalPair() : key(0), val() {}
+    explicit InternalPair(DictKey k) : key(k), val() {}
+    InternalPair(DictKey k, const RDValue &v) : key(k), val(v) {}
+    void cleanup() { RDValue::cleanup_rdvalue(val); }
+  };
+
   struct Pair {
     std::string key;
     RDValue val;
@@ -44,19 +55,18 @@ class RDKIT_RDGENERAL_EXPORT Dict {
     explicit Pair(std::string_view s) : key(std::string(s)), val() {}
     Pair(std::string s, const RDValue &v) : key(std::move(s)), val(v) {}
     Pair(std::string_view s, const RDValue &v) : key(std::string(s)), val(v) {}
-    // In the case you are holding onto an rdvalue outside of a dictionary
-    //  or other container, you kust call cleanup to release non POD memory.
     void cleanup() { RDValue::cleanup_rdvalue(val); }
   };
 
   typedef std::vector<Pair> DataType;
+  typedef std::vector<InternalPair> InternalDataType;
 
   Dict() {}
 
   Dict(const Dict &other) : _data(other._data) {
     _hasNonPodData = other._hasNonPodData;
-    if (other._hasNonPodData) {  // other has non pod data, need to copy
-      std::vector<Pair> data(other._data.size());
+    if (other._hasNonPodData) {
+      InternalDataType data(other._data.size());
       _data.swap(data);
       for (size_t i = 0; i < _data.size(); ++i) {
         _data[i].key = other._data[i].key;
@@ -68,7 +78,7 @@ class RDKIT_RDGENERAL_EXPORT Dict {
   Dict(Dict &&other) noexcept = default;
 
   ~Dict() {
-    reset();  // to clear pointers if necessary
+    reset();
   }
 
   void update(const Dict &other, bool preserveExisting = false) {
@@ -79,7 +89,7 @@ class RDKIT_RDGENERAL_EXPORT Dict {
         _hasNonPodData = true;
       }
       for (const auto &opair : other._data) {
-        Pair *target = nullptr;
+        InternalPair *target = nullptr;
         for (auto &dpair : _data) {
           if (dpair.key == opair.key) {
             target = &dpair;
@@ -88,11 +98,9 @@ class RDKIT_RDGENERAL_EXPORT Dict {
         }
 
         if (!target) {
-          // need to create blank entry and copy
-          _data.push_back(Pair(opair.key));
+          _data.push_back(InternalPair(opair.key));
           copy_rdvalue(_data.back().val, opair.val);
         } else {
-          // just copy
           copy_rdvalue(target->val, opair.val);
         }
       }
@@ -108,7 +116,7 @@ class RDKIT_RDGENERAL_EXPORT Dict {
     }
 
     if (other._hasNonPodData) {
-      std::vector<Pair> data(other._data.size());
+      InternalDataType data(other._data.size());
       _data.swap(data);
       for (size_t i = 0; i < _data.size(); ++i) {
         _data[i].key = other._data[i].key;
@@ -141,43 +149,49 @@ class RDKIT_RDGENERAL_EXPORT Dict {
   //! \brief Returns whether the dictionary is empty
   bool empty() const { return _data.empty(); }
 
-  using const_iterator = DataType::const_iterator;
-  const_iterator begin() const { return _data.begin(); }
-  const_iterator end() const { return _data.end(); }
+  //! \brief Access to the underlying non-POD containment flag
+  bool &getNonPODStatus() { return _hasNonPodData; }
 
-  //! \brief Appends a populated Pair to the dictionary.
-  void insert(Pair &&pair) {
-    _hasNonPodData |= pair.val.needsCleanup();
-    _data.push_back(std::move(pair));
-  }
-
-  //! \brief Bulk-appends a vector of Pairs, moving them into the dictionary.
-  void extend(std::vector<Pair> &&pairs) {
-    for (auto &p : pairs) {
-      _hasNonPodData |= p.val.needsCleanup();
+  //----------------------------------------------------------
+  //! \brief Access to the underlying data as external Pairs (string keys).
+  DataType getData() const {
+    DataType result;
+    result.reserve(_data.size());
+    for (const auto &ip : _data) {
+      result.push_back(Pair(keyToString(ip.key), ip.val));
     }
-    _data.insert(_data.end(), std::make_move_iterator(pairs.begin()),
-                 std::make_move_iterator(pairs.end()));
+    return result;
   }
+
+  //! \brief Direct access to the internal storage (integer keys).
+  const InternalDataType &getInternalData() const { return _data; }
+  InternalDataType &getInternalData() { return _data; }
 
   //! \brief Returns a const reference to the RDValue for a key.
   //! Throws KeyErrorException if the key is not found.
-  const RDValue &getRDValue(const std::string_view what) const {
+  const RDValue &getRDValue(std::string_view what) const {
+    DictKey k = internKey(what);
+    return getRDValue(k);
+  }
+  const RDValue &getRDValue(DictKey k) const {
     for (const auto &data : _data) {
-      if (data.key == what) {
+      if (data.key == k) {
         return data.val;
       }
     }
-    throw KeyErrorException(what);
+    throw KeyErrorException(keyToString(k));
   }
 
   //----------------------------------------------------------
 
-  //! \brief Returns whether or not the dictionary contains a particular
-  //!        key.
-  bool hasVal(const std::string_view what) const {
+  //! \brief Returns whether or not the dictionary contains a particular key.
+  bool hasVal(std::string_view what) const {
+    DictKey k = internKey(what);
+    return hasVal(k);
+  }
+  bool hasVal(DictKey k) const {
     for (const auto &data : _data) {
-      if (data.key == what) {
+      if (data.key == k) {
         return true;
       }
     }
@@ -186,76 +200,66 @@ class RDKIT_RDGENERAL_EXPORT Dict {
 
   //----------------------------------------------------------
   //! Returns the set of keys in the dictionary
-  /*!
-     \return  a \c STR_VECT
-  */
   STR_VECT keys() const {
     STR_VECT res;
     res.reserve(_data.size());
     for (const auto &item : _data) {
-      res.push_back(item.key);
+      res.push_back(keyToString(item.key));
     }
     return res;
   }
 
   //----------------------------------------------------------
   //! \brief Gets the value associated with a particular key
-  /*!
-     \param what  the key to lookup
-     \param res   a reference used to return the result
-
-     <b>Notes:</b>
-      - If \c res is a \c std::string, every effort will be made
-        to convert the specified element to a string using the
-        \c boost::lexical_cast machinery.
-      - If the dictionary does not contain the key \c what,
-        a KeyErrorException will be thrown.
-  */
   template <typename T>
-  void getVal(const std::string_view what, T &res) const {
+  void getVal(std::string_view what, T &res) const {
     res = getVal<T>(what);
   }
-
-  //! \overload
   template <typename T>
-  T getVal(const std::string_view what) const {
+  void getVal(DictKey k, T &res) const {
+    res = getVal<T>(k);
+  }
+
+  template <typename T>
+  T getVal(std::string_view what) const {
+    DictKey k = internKey(what);
+    return getVal<T>(k);
+  }
+  template <typename T>
+  T getVal(DictKey k) const {
     for (auto &data : _data) {
-      if (data.key == what) {
+      if (data.key == k) {
         return from_rdvalue<T>(data.val);
       }
     }
-    throw KeyErrorException(what);
+    throw KeyErrorException(keyToString(k));
   }
 
-  //! \overload
-  void getVal(const std::string_view what, std::string &res) const {
+  void getVal(std::string_view what, std::string &res) const {
+    DictKey k = internKey(what);
+    getVal(k, res);
+  }
+  void getVal(DictKey k, std::string &res) const {
     for (const auto &i : _data) {
-      if (i.key == what) {
+      if (i.key == k) {
         rdvalue_tostring(i.val, res);
         return;
       }
     }
-    throw KeyErrorException(what);
+    throw KeyErrorException(keyToString(k));
   }
 
   //----------------------------------------------------------
   //! \brief Potentially gets the value associated with a particular key
-  //!        returns true on success/false on failure.
-  /*!
-     \param what  the key to lookup
-     \param res   a reference used to return the result
-
-     <b>Notes:</b>
-      - If \c res is a \c std::string, every effort will be made
-        to convert the specified element to a string using the
-        \c boost::lexical_cast machinery.
-      - If the dictionary does not contain the key \c what,
-        a KeyErrorException will be thrown.
-  */
   template <typename T>
-  bool getValIfPresent(const std::string_view what, T &res) const {
+  bool getValIfPresent(std::string_view what, T &res) const {
+    DictKey k = internKey(what);
+    return getValIfPresent(k, res);
+  }
+  template <typename T>
+  bool getValIfPresent(DictKey k, T &res) const {
     for (const auto &data : _data) {
-      if (data.key == what) {
+      if (data.key == k) {
         res = from_rdvalue<T>(data.val);
         return true;
       }
@@ -263,10 +267,13 @@ class RDKIT_RDGENERAL_EXPORT Dict {
     return false;
   }
 
-  //! \overload
-  bool getValIfPresent(const std::string_view what, std::string &res) const {
+  bool getValIfPresent(std::string_view what, std::string &res) const {
+    DictKey k = internKey(what);
+    return getValIfPresent(k, res);
+  }
+  bool getValIfPresent(DictKey k, std::string &res) const {
     for (const auto &i : _data) {
-      if (i.key == what) {
+      if (i.key == k) {
         rdvalue_tostring(i.val, res);
         return true;
       }
@@ -276,107 +283,112 @@ class RDKIT_RDGENERAL_EXPORT Dict {
 
   //----------------------------------------------------------
   //! \brief Sets the value associated with a key
-  /*!
-
-     \param what the key to set
-     \param val  the value to store
-
-     <b>Notes:</b>
-        - If \c val is a <tt>const char *</tt>, it will be converted
-           to a \c std::string for storage.
-        - If the dictionary already contains the key \c what,
-          the value will be replaced.
-  */
   template <typename T>
-  void setVal(const std::string_view what, T &val) {
+  void setVal(std::string_view what, T &val) {
     static_assert(!std::is_same_v<T, std::string_view>,
                   "T cannot be string_view");
     if (what.empty()) {
       throw ValueErrorException("Cannot set value with empty key");
     }
+    DictKey k = internKey(what);
+    setVal(k, val);
+  }
+  template <typename T>
+  void setVal(DictKey k, T &val) {
     _hasNonPodData = true;
     for (auto &&data : _data) {
-      if (data.key == what) {
+      if (data.key == k) {
         RDValue::cleanup_rdvalue(data.val);
         data.val = val;
         return;
       }
     }
-    _data.push_back(Pair(what, val));
+    _data.emplace_back(k, val);
   }
 
   template <typename T>
-  void setPODVal(const std::string_view what, T val) {
+  void setPODVal(std::string_view what, T val) {
     static_assert(!std::is_same_v<T, std::string_view>,
                   "T cannot be string_view");
     if (what.empty()) {
       throw ValueErrorException("Cannot set value with empty key");
     }
-    // don't change the hasNonPodData status
+    DictKey k = internKey(what);
+    setPODVal(k, val);
+  }
+  template <typename T>
+  void setPODVal(DictKey k, T val) {
     for (auto &&data : _data) {
-      if (data.key == what) {
+      if (data.key == k) {
         RDValue::cleanup_rdvalue(data.val);
         data.val = val;
         return;
       }
     }
-    _data.push_back(Pair(what, val));
+    _data.emplace_back(k, val);
   }
 
-  void setVal(const std::string_view what, bool val) {
+  void setVal(std::string_view what, bool val) {
     if (what.empty()) {
       throw ValueErrorException("Cannot set value with empty key");
     }
     setPODVal(what, val);
   }
+  void setVal(DictKey k, bool val) { setPODVal(k, val); }
 
-  void setVal(const std::string_view what, double val) {
+  void setVal(std::string_view what, double val) {
     if (what.empty()) {
       throw ValueErrorException("Cannot set value with empty key");
     }
     setPODVal(what, val);
   }
+  void setVal(DictKey k, double val) { setPODVal(k, val); }
 
-  void setVal(const std::string_view what, float val) {
+  void setVal(std::string_view what, float val) {
     if (what.empty()) {
       throw ValueErrorException("Cannot set value with empty key");
     }
     setPODVal(what, val);
   }
-  void setVal(const std::string_view what, int val) {
+  void setVal(DictKey k, float val) { setPODVal(k, val); }
+
+  void setVal(std::string_view what, int val) {
     if (what.empty()) {
       throw ValueErrorException("Cannot set value with empty key");
     }
     setPODVal(what, val);
   }
+  void setVal(DictKey k, int val) { setPODVal(k, val); }
 
-  void setVal(const std::string_view what, unsigned int val) {
+  void setVal(std::string_view what, unsigned int val) {
     if (what.empty()) {
       throw ValueErrorException("Cannot set value with empty key");
     }
     setPODVal(what, val);
   }
+  void setVal(DictKey k, unsigned int val) { setPODVal(k, val); }
 
-  //! \overload
-  void setVal(const std::string_view what, const char *val) {
+  void setVal(std::string_view what, const char *val) {
     if (what.empty()) {
       throw ValueErrorException("Cannot set value with empty key");
     }
     std::string h(val);
     setVal(what, h);
   }
+  void setVal(DictKey k, const char *val) {
+    std::string h(val);
+    setVal(k, h);
+  }
 
   //----------------------------------------------------------
-  //! \brief Clears the value associated with a particular key,
-  //!     removing the key from the dictionary.
-  /*!
-
-     \param what the key to clear
-
-  */
-  void clearVal(const std::string_view what) {
+  //! \brief Clears the value associated with a particular key.
+  void clearVal(std::string_view what) {
+    DictKey k = internKey(what);
+    clearVal(k);
+  }
+  void clearVal(DictKey k) {
     for (auto it = _data.begin(); it < _data.end(); ++it) {
-      if (it->key == what) {
+      if (it->key == k) {
         if (_hasNonPodData) {
           RDValue::cleanup_rdvalue(it->val);
         }
@@ -388,34 +400,34 @@ class RDKIT_RDGENERAL_EXPORT Dict {
 
   //----------------------------------------------------------
   //! \brief Clears all keys (and values) from the dictionary.
-  //!
   void reset() {
     if (_hasNonPodData) {
       for (auto &&data : _data) {
         RDValue::cleanup_rdvalue(data.val);
       }
     }
-    DataType data;
+    InternalDataType data;
     _data.swap(data);
   }
 
  private:
-  DataType _data{};            //!< the actual dictionary
-  bool _hasNonPodData{false};  // if true, need a deep copy
-                               //  (copy_rdvalue)
+  InternalDataType _data{};
+  bool _hasNonPodData{false};
 };
 
 template <>
-inline std::string Dict::getVal<std::string>(
-    const std::string_view what) const {
+inline std::string Dict::getVal<std::string>(std::string_view what) const {
   std::string res;
   getVal(what, res);
   return res;
 }
+template <>
+inline std::string Dict::getVal<std::string>(DictKey k) const {
+  std::string res;
+  getVal(k, res);
+  return res;
+}
 
-// Utility class for holding a Dict::Pair
-//  Dict::Pairs require containers for memory management
-//  This utility class covers cleanup and copying
 class PairHolder : public Dict::Pair {
  public:
   PairHolder() : Pair() {}

--- a/Code/RDGeneral/DictKeyIntern.h
+++ b/Code/RDGeneral/DictKeyIntern.h
@@ -221,18 +221,20 @@ inline DictKey internKey(std::string_view s) {
   struct CacheEntry {
     std::string key;
     DictKey val{0};
+    bool occupied{false};
   };
   static constexpr size_t kCacheSize = 64;
   static thread_local std::array<CacheEntry, kCacheSize> tl_cache{};
 
   size_t h = std::hash<std::string_view>{}(s) % kCacheSize;
   auto &entry = tl_cache[h];
-  if (entry.key.size() == s.size() && entry.key == s) {
+  if (entry.occupied && entry.key.size() == s.size() && entry.key == s) {
     return entry.val;
   }
   DictKey k = DictKeyIntern::instance().intern(s);
   entry.key.assign(s.data(), s.size());
   entry.val = k;
+  entry.occupied = true;
   return k;
 }
 inline const std::string &keyToString(DictKey k) {

--- a/Code/RDGeneral/DictKeyIntern.h
+++ b/Code/RDGeneral/DictKeyIntern.h
@@ -1,0 +1,82 @@
+#include <RDGeneral/export.h>
+#ifndef RD_DICT_KEY_INTERN_H
+#define RD_DICT_KEY_INTERN_H
+
+#include <cstdint>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace RDKit {
+
+using DictKey = std::uint16_t;
+
+class RDKIT_RDGENERAL_EXPORT DictKeyIntern {
+ public:
+  static DictKeyIntern &instance() {
+    static DictKeyIntern inst;
+    return inst;
+  }
+
+  DictKey intern(std::string_view s) {
+    {
+      std::shared_lock lock(d_mtx);
+      auto it = d_str2key.find(s);
+      if (it != d_str2key.end()) {
+        return it->second;
+      }
+    }
+    std::unique_lock lock(d_mtx);
+    auto [it, inserted] = d_str2key.emplace(std::string(s), 0);
+    if (inserted) {
+      DictKey k = static_cast<DictKey>(d_key2str.size());
+      it->second = k;
+      d_key2str.push_back(it->first);
+    }
+    return it->second;
+  }
+
+  const std::string &toString(DictKey k) const { return d_key2str[k]; }
+
+ private:
+  DictKeyIntern() {
+    d_str2key.reserve(256);
+    d_key2str.reserve(256);
+  }
+  DictKeyIntern(const DictKeyIntern &) = delete;
+  DictKeyIntern &operator=(const DictKeyIntern &) = delete;
+
+  struct SVHash {
+    using is_transparent = void;
+    size_t operator()(std::string_view s) const {
+      return std::hash<std::string_view>{}(s);
+    }
+    size_t operator()(const std::string &s) const {
+      return std::hash<std::string_view>{}(std::string_view(s));
+    }
+  };
+  struct SVEqual {
+    using is_transparent = void;
+    bool operator()(std::string_view a, std::string_view b) const {
+      return a == b;
+    }
+  };
+
+  std::shared_mutex d_mtx;
+  std::unordered_map<std::string, DictKey, SVHash, SVEqual> d_str2key;
+  std::vector<std::string> d_key2str;
+};
+
+inline DictKey internKey(std::string_view s) {
+  return DictKeyIntern::instance().intern(s);
+}
+inline const std::string &keyToString(DictKey k) {
+  return DictKeyIntern::instance().toString(k);
+}
+
+}  // namespace RDKit
+
+#endif

--- a/Code/RDGeneral/DictKeyIntern.h
+++ b/Code/RDGeneral/DictKeyIntern.h
@@ -2,7 +2,9 @@
 #ifndef RD_DICT_KEY_INTERN_H
 #define RD_DICT_KEY_INTERN_H
 
+#include <array>
 #include <cstdint>
+#include <functional>
 #include <mutex>
 #include <shared_mutex>
 #include <string>
@@ -13,6 +15,145 @@
 namespace RDKit {
 
 using DictKey = std::uint16_t;
+
+inline constexpr std::string_view kWellKnownKeys[] = {
+    "__computedProps",
+    "2D",
+    "BalabanJ",
+    "BalanbanJ",
+    "Discrims",
+    "DistanceMatrix_Paths",
+    "MolFileComments",
+    "MolFileInfo",
+    "NullBond",
+    "_2DConf",
+    "_3DConf",
+    "_AtomID",
+    "_BondsPotentialStereo",
+    "_chiralAtomRank",
+    "_CIPCode",
+    "_CIPRank",
+    "_CIPComputed",
+    "_CIPNeighborOrder",
+    "_CanonicalRankingNumber",
+    "_ChiralityPossible",
+    "_CrippenLogP",
+    "_CrippenMR",
+    "_MMFFSanitized",
+    "_MolFileChiralFlag",
+    "MRV SMA",
+    "_MolFileRLabel",
+    "_MolFileAtomQuery",
+    "_MolFileBondQuery",
+    "_MolFileBondEndPts",
+    "_MolFileBondAttach",
+    "_MolFileBondType",
+    "_MolFileBondStereo",
+    "_MolFileBondCfg",
+    "_Name",
+    "_NeedsQueryScan",
+    "_NonExplicit3DChirality",
+    "_QueryFormalCharge",
+    "_QueryHCount",
+    "_QueryIsotope",
+    "_QueryMass",
+    "_ReactionDegreeChanged",
+    "react_atom_idx",
+    "old_mapno",
+    "react_idx",
+    "_RingClosures",
+    "_SLN_s",
+    "_SmilesStart",
+    "_StereochemDone",
+    "_TraversalBondIndexOrder",
+    "_TraversalRingClosureBond",
+    "_TraversalStartPoint",
+    "_TriposAtomType",
+    "_Unfinished_SLN_",
+    "_UnknownStereo",
+    "_connectivityHKDeltas",
+    "_connectivityNVals",
+    "_crippenLogP",
+    "_crippenLogPContribs",
+    "_crippenMR",
+    "_crippenMRContribs",
+    "_GasteigerCharge",
+    "_GasteigerHCharge",
+    "_doIsoSmiles",
+    "_fragSMARTS",
+    "_hasMassQuery",
+    "_labuteASA",
+    "_labuteAtomContribs",
+    "_labuteAtomHContrib",
+    "_protected",
+    "_queryRootAtom",
+    "_ringStereoAtoms",
+    "_ringStereoWarning",
+    "_ringStereochemCand",
+    "_ringStereoOtherAtom",
+    "_mesoOtherAtom",
+    "_chiralPermutation",
+    "_smilesAtomOutputOrder",
+    "_smilesBondOutputOrder",
+    "_starred",
+    "_supplementalSmilesLabel",
+    "_tpsa",
+    "_tpsaAtomContribs",
+    "_unspecifiedOrder",
+    "_brokenChirality",
+    "_rgroupAtomMaps",
+    "_rgroupBonds",
+    "_rgroupTargetAtoms",
+    "_rgroupTargetBonds",
+    "dummyLabel",
+    "extraRings",
+    "isImplicit",
+    "maxAttachIdx",
+    "molAtomMapNumber",
+    "molFileAlias",
+    "molFileValue",
+    "molInversionFlag",
+    "molParity",
+    "molStereoCare",
+    "molRxnComponent",
+    "molRxnRole",
+    "molTotValence",
+    "_molLinkNodes",
+    "numArom",
+    "ringMembership",
+    "smilesSymbol",
+    "atomLabel",
+    "OxidationNumber",
+    "internalRgroupSmiles",
+    "molRingBondCount",
+    "molSubstCount",
+    "molAttchpt",
+    "molAttchord",
+    "molAttachOrderTemplate",
+    "molClass",
+    "molSeqid",
+    "molSeqName",
+    "molRxnExachg",
+    "molReactStatus",
+    "_fromAttchpt",
+    "natReplace",
+    "templateNames",
+    "molNote",
+    "atomNote",
+    "bondNote",
+    "_isotopicHs",
+    "_QueryAtomGenericLabel",
+    "_displayLabel",
+    "_displayLabelW",
+    "_cxsmilesBondIdx",
+    "_cxsmilesOutputIndex",
+    "_needsDetectAtomStereo",
+    "_needsDetectBondStereo",
+    "_potentialStereo",
+    "_stereoGroup",
+};
+inline constexpr size_t kNumWellKnown =
+    sizeof(kWellKnownKeys) / sizeof(kWellKnownKeys[0]);
 
 class RDKIT_RDGENERAL_EXPORT DictKeyIntern {
  public:
@@ -30,13 +171,14 @@ class RDKIT_RDGENERAL_EXPORT DictKeyIntern {
       }
     }
     std::unique_lock lock(d_mtx);
-    auto [it, inserted] = d_str2key.emplace(std::string(s), 0);
-    if (inserted) {
-      DictKey k = static_cast<DictKey>(d_key2str.size());
-      it->second = k;
-      d_key2str.push_back(it->first);
+    auto it = d_str2key.find(s);
+    if (it != d_str2key.end()) {
+      return it->second;
     }
-    return it->second;
+    DictKey k = static_cast<DictKey>(d_key2str.size());
+    auto [ins, _] = d_str2key.emplace(std::string(s), k);
+    d_key2str.push_back(ins->first);
+    return k;
   }
 
   const std::string &toString(DictKey k) const { return d_key2str[k]; }
@@ -45,6 +187,11 @@ class RDKIT_RDGENERAL_EXPORT DictKeyIntern {
   DictKeyIntern() {
     d_str2key.reserve(256);
     d_key2str.reserve(256);
+    for (size_t i = 0; i < kNumWellKnown; ++i) {
+      auto [ins, _] = d_str2key.emplace(std::string(kWellKnownKeys[i]),
+                                         static_cast<DictKey>(i));
+      d_key2str.push_back(ins->first);
+    }
   }
   DictKeyIntern(const DictKeyIntern &) = delete;
   DictKeyIntern &operator=(const DictKeyIntern &) = delete;
@@ -65,13 +212,28 @@ class RDKIT_RDGENERAL_EXPORT DictKeyIntern {
     }
   };
 
-  std::shared_mutex d_mtx;
+  mutable std::shared_mutex d_mtx;
   std::unordered_map<std::string, DictKey, SVHash, SVEqual> d_str2key;
   std::vector<std::string> d_key2str;
 };
 
 inline DictKey internKey(std::string_view s) {
-  return DictKeyIntern::instance().intern(s);
+  struct CacheEntry {
+    std::string key;
+    DictKey val{0};
+  };
+  static constexpr size_t kCacheSize = 64;
+  static thread_local std::array<CacheEntry, kCacheSize> tl_cache{};
+
+  size_t h = std::hash<std::string_view>{}(s) % kCacheSize;
+  auto &entry = tl_cache[h];
+  if (entry.key.size() == s.size() && entry.key == s) {
+    return entry.val;
+  }
+  DictKey k = DictKeyIntern::instance().intern(s);
+  entry.key.assign(s.data(), s.size());
+  entry.val = k;
+  return k;
 }
 inline const std::string &keyToString(DictKey k) {
   return DictKeyIntern::instance().toString(k);

--- a/Code/RDGeneral/RDProps.h
+++ b/Code/RDGeneral/RDProps.h
@@ -44,14 +44,13 @@ class RDProps {
   //  all setProp functions are const because they
   //     are not meant to change the atom chemically
   // ------------------------------------
-  //! returns a list with the names of our \c properties
   STR_VECT getPropList(bool includePrivate = true,
                        bool includeComputed = true) const {
     const STR_VECT &tmp = d_props.keys();
     STR_VECT res, computed;
     if (!includeComputed &&
         getPropIfPresent(RDKit::detail::computedPropName, computed)) {
-      computed.emplace_back(RDKit::detail::computedPropName);
+      computed.emplace_back(keyToString(RDKit::detail::computedPropName));
     }
 
     auto pos = tmp.begin();
@@ -65,93 +64,66 @@ class RDProps {
     return res;
   }
 
-  //! sets a \c property value
-  /*!
-    \param key the name under which the \c property should be stored.
-    If a \c property is already stored under this name, it will be
-    replaced.
-    \param val the value to be stored
-    \param computed (optional) allows the \c property to be flagged
-    \c computed.
-  */
-
-  //! \overload
   template <typename T>
   void setProp(const std::string_view key, T val, bool computed = false) const {
-    if(key.empty()) {
+    if (key.empty()) {
       throw ValueErrorException("Cannot set property with empty key");
     }
+    DictKey dk = internKey(key);
     if (computed) {
-      STR_VECT compLst;
-      getPropIfPresent(RDKit::detail::computedPropName, compLst);
-      if (std::find(compLst.begin(), compLst.end(), key) == compLst.end()) {
-        compLst.emplace_back(key);
-        d_props.setVal(RDKit::detail::computedPropName, compLst);
-      }
+      addComputedKey(dk);
+    }
+    d_props.setVal(dk, val);
+  }
+
+  template <typename T>
+  void setProp(DictKey key, T val, bool computed = false) const {
+    if (computed) {
+      addComputedKey(key);
     }
     d_props.setVal(key, val);
   }
 
-  //! allows retrieval of a particular property value
-  /*!
-
-    \param key the name under which the \c property should be stored.
-    If a \c property is already stored under this name, it will be
-    replaced.
-    \param res a reference to the storage location for the value.
-
-    <b>Notes:</b>
-    - if no \c property with name \c key exists, a KeyErrorException will be
-    thrown.
-    - the \c boost::lexical_cast machinery is used to attempt type
-    conversions.
-    If this fails, a \c boost::bad_lexical_cast exception will be thrown.
-
-  */
-  //! \overload
   template <typename T>
   void getProp(const std::string_view key, T &res) const {
     d_props.getVal(key, res);
   }
+  template <typename T>
+  void getProp(DictKey key, T &res) const {
+    d_props.getVal(key, res);
+  }
 
-  //! \overload
   template <typename T>
   T getProp(const std::string_view key) const {
     return d_props.getVal<T>(key);
   }
+  template <typename T>
+  T getProp(DictKey key) const {
+    return d_props.getVal<T>(key);
+  }
 
-  //! returns whether or not we have a \c property with name \c key
-  //!  and assigns the value if we do
-  //! \overload
   template <typename T>
   bool getPropIfPresent(const std::string_view key, T &res) const {
     return d_props.getValIfPresent(key, res);
   }
+  template <typename T>
+  bool getPropIfPresent(DictKey key, T &res) const {
+    return d_props.getValIfPresent(key, res);
+  }
 
-  //! \overload
   bool hasProp(const std::string_view key) const { return d_props.hasVal(key); }
+  bool hasProp(DictKey key) const { return d_props.hasVal(key); }
 
-  //! clears the value of a \c property
-  /*!
-    <b>Notes:</b>
-    - if no \c property with name \c key exists, this will be a no-op.
-    - if the \c property is marked as \c computed, it will also be removed
-    from our list of \c computedProperties
-  */
-  //! \overload
   void clearProp(const std::string_view key) const {
-    STR_VECT compLst;
-    if (getPropIfPresent(RDKit::detail::computedPropName, compLst)) {
-      auto svi = std::find(compLst.begin(), compLst.end(), key);
-      if (svi != compLst.end()) {
-        compLst.erase(svi);
-        d_props.setVal(RDKit::detail::computedPropName, compLst);
-      }
-    }
+    DictKey dk = internKey(key);
+    removeComputedKey(dk);
+    d_props.clearVal(dk);
+  }
+  void clearProp(DictKey key) const {
+    removeComputedKey(key);
     d_props.clearVal(key);
   }
 
-  //! clears all of our \c computed \c properties
   void clearComputedProps() const {
     STR_VECT compLst;
     if (getPropIfPresent(RDKit::detail::computedPropName, compLst) &&
@@ -163,6 +135,30 @@ class RDProps {
       d_props.setVal(RDKit::detail::computedPropName, compLst);
     }
   }
+
+ private:
+  void addComputedKey(DictKey dk) const {
+    STR_VECT compLst;
+    getPropIfPresent(RDKit::detail::computedPropName, compLst);
+    const std::string &ks = keyToString(dk);
+    if (std::find(compLst.begin(), compLst.end(), ks) == compLst.end()) {
+      compLst.push_back(ks);
+      d_props.setVal(RDKit::detail::computedPropName, compLst);
+    }
+  }
+  void removeComputedKey(DictKey dk) const {
+    STR_VECT compLst;
+    if (getPropIfPresent(RDKit::detail::computedPropName, compLst)) {
+      const std::string &ks = keyToString(dk);
+      auto svi = std::find(compLst.begin(), compLst.end(), ks);
+      if (svi != compLst.end()) {
+        compLst.erase(svi);
+        d_props.setVal(RDKit::detail::computedPropName, compLst);
+      }
+    }
+  }
+
+ public:
 
   //! update the properties from another
   /*

--- a/Code/RDGeneral/StreamOps.h
+++ b/Code/RDGeneral/StreamOps.h
@@ -658,6 +658,12 @@ inline bool streamReadProp(std::istream &ss, Dict::Pair &pair,
   return ok;
 }
 
+inline bool streamReadProp(std::istream &ss, Dict::Pair &pair,
+                           const CustomPropHandlerVec &handlers = {}) {
+  bool unused = false;
+  return streamReadProp(ss, pair, unused, handlers);
+}
+
 template <typename COUNT_TYPE = unsigned int>
 inline unsigned int streamReadProps(std::istream &ss, RDProps &props,
                                     const CustomPropHandlerVec &handlers = {},

--- a/Code/RDGeneral/StreamOps.h
+++ b/Code/RDGeneral/StreamOps.h
@@ -386,9 +386,9 @@ class CustomPropHandler {
 typedef std::vector<std::shared_ptr<const CustomPropHandler>>
     CustomPropHandlerVec;
 
-inline bool isSerializable(const Dict::Pair &pair,
+inline bool isSerializable(const RDValue &val,
                            const CustomPropHandlerVec &handlers = {}) {
-  switch (pair.val.getTag()) {
+  switch (val.getTag()) {
     case RDTypeTag::StringTag:
     case RDTypeTag::IntTag:
     case RDTypeTag::UnsignedIntTag:
@@ -404,7 +404,7 @@ inline bool isSerializable(const Dict::Pair &pair,
       return true;
     case RDTypeTag::AnyTag:
       for (auto &handler : handlers) {
-        if (handler->canSerialize(pair.val)) {
+        if (handler->canSerialize(val)) {
           return true;
         }
       }
@@ -413,70 +413,75 @@ inline bool isSerializable(const Dict::Pair &pair,
       return false;
   }
 }
+inline bool isSerializable(const Dict::Pair &pair,
+                           const CustomPropHandlerVec &handlers = {}) {
+  return isSerializable(pair.val, handlers);
+}
+inline bool isSerializable(const Dict::InternalPair &pair,
+                           const CustomPropHandlerVec &handlers = {}) {
+  return isSerializable(pair.val, handlers);
+}
 
-inline bool streamWriteProp(std::ostream &ss, const Dict::Pair &pair,
+inline bool streamWriteProp(std::ostream &ss, const std::string &key,
+                            const RDValue &val,
                             const CustomPropHandlerVec &handlers = {}) {
-  if (!isSerializable(pair, handlers)) {
+  if (!isSerializable(val, handlers)) {
     return false;
   }
 
-  streamWrite(ss, pair.key);
-  switch (pair.val.getTag()) {
+  streamWrite(ss, key);
+  switch (val.getTag()) {
     case RDTypeTag::StringTag:
       streamWrite(ss, DTags::StringTag);
-      streamWrite(ss, rdvalue_cast<std::string>(pair.val));
+      streamWrite(ss, rdvalue_cast<std::string>(val));
       break;
     case RDTypeTag::IntTag:
       streamWrite(ss, DTags::IntTag);
-      streamWrite(ss, rdvalue_cast<int>(pair.val));
+      streamWrite(ss, rdvalue_cast<int>(val));
       break;
     case RDTypeTag::UnsignedIntTag:
       streamWrite(ss, DTags::UnsignedIntTag);
-      streamWrite(ss, rdvalue_cast<unsigned int>(pair.val));
+      streamWrite(ss, rdvalue_cast<unsigned int>(val));
       break;
     case RDTypeTag::BoolTag:
       streamWrite(ss, DTags::BoolTag);
-      streamWrite(ss, rdvalue_cast<bool>(pair.val));
+      streamWrite(ss, rdvalue_cast<bool>(val));
       break;
     case RDTypeTag::FloatTag:
       streamWrite(ss, DTags::FloatTag);
-      streamWrite(ss, rdvalue_cast<float>(pair.val));
+      streamWrite(ss, rdvalue_cast<float>(val));
       break;
     case RDTypeTag::DoubleTag:
       streamWrite(ss, DTags::DoubleTag);
-      streamWrite(ss, rdvalue_cast<double>(pair.val));
+      streamWrite(ss, rdvalue_cast<double>(val));
       break;
 
     case RDTypeTag::VecStringTag:
       streamWrite(ss, DTags::VecStringTag);
-      streamWriteVec(ss, rdvalue_cast<std::vector<std::string>>(pair.val));
+      streamWriteVec(ss, rdvalue_cast<std::vector<std::string>>(val));
       break;
     case RDTypeTag::VecDoubleTag:
       streamWrite(ss, DTags::VecDoubleTag);
-      streamWriteVec(ss, rdvalue_cast<std::vector<double>>(pair.val));
+      streamWriteVec(ss, rdvalue_cast<std::vector<double>>(val));
       break;
     case RDTypeTag::VecFloatTag:
       streamWrite(ss, DTags::VecFloatTag);
-      streamWriteVec(ss, rdvalue_cast<std::vector<float>>(pair.val));
+      streamWriteVec(ss, rdvalue_cast<std::vector<float>>(val));
       break;
     case RDTypeTag::VecIntTag:
       streamWrite(ss, DTags::VecIntTag);
-      streamWriteVec(ss, rdvalue_cast<std::vector<int>>(pair.val));
+      streamWriteVec(ss, rdvalue_cast<std::vector<int>>(val));
       break;
     case RDTypeTag::VecUnsignedIntTag:
       streamWrite(ss, DTags::VecUIntTag);
-      streamWriteVec(ss, rdvalue_cast<std::vector<unsigned int>>(pair.val));
+      streamWriteVec(ss, rdvalue_cast<std::vector<unsigned int>>(val));
       break;
     default:
       for (auto &handler : handlers) {
-        if (handler->canSerialize(pair.val)) {
-          // The form of a custom tag is
-          //  CustomTag
-          //  customPropName (must be unique)
-          //  custom serialization
+        if (handler->canSerialize(val)) {
           streamWrite(ss, DTags::CustomTag);
           streamWrite(ss, std::string(handler->getPropName()));
-          handler->write(ss, pair.val);
+          handler->write(ss, val);
           return true;
         }
       }
@@ -484,6 +489,14 @@ inline bool streamWriteProp(std::ostream &ss, const Dict::Pair &pair,
       return false;
   }
   return true;
+}
+inline bool streamWriteProp(std::ostream &ss, const Dict::Pair &pair,
+                            const CustomPropHandlerVec &handlers = {}) {
+  return streamWriteProp(ss, pair.key, pair.val, handlers);
+}
+inline bool streamWriteProp(std::ostream &ss, const Dict::InternalPair &pair,
+                            const CustomPropHandlerVec &handlers = {}) {
+  return streamWriteProp(ss, keyToString(pair.key), pair.val, handlers);
 }
 
 template <typename COUNT_TYPE = unsigned int>
@@ -500,25 +513,28 @@ inline bool streamWriteProps(
   }
 
   const Dict &dict = props.getDict();
+  std::unordered_set<DictKey> internedKeys;
+  for (const auto &pn : propnames) {
+    internedKeys.insert(internKey(pn));
+  }
+
   COUNT_TYPE count = 0;
-  for (const auto &elem : dict) {
-    if (propnames.find(elem.key) != propnames.end()) {
+  for (const auto &elem : dict.getInternalData()) {
+    if (internedKeys.count(elem.key)) {
       if (isSerializable(elem, handlers)) {
         count++;
       }
     }
   }
-  streamWrite(ss, count);  // packed int?
+  streamWrite(ss, count);
   if (!count) {
     return false;
   }
 
   COUNT_TYPE writtenCount = 0;
-  for (const auto &elem : dict) {
-    if (propnames.find(elem.key) != propnames.end()) {
+  for (const auto &elem : dict.getInternalData()) {
+    if (internedKeys.count(elem.key)) {
       if (isSerializable(elem, handlers)) {
-        // note - not all properties are serializable, this may be
-        //  a null op
         if (streamWriteProp(ss, elem, handlers)) {
           writtenCount++;
         }
@@ -558,10 +574,13 @@ inline void readRDStringVecValue(std::istream &ss, RDValue &value) {
   value = v;
 }
 
-inline bool streamReadProp(std::istream &ss, Dict::Pair &pair,
+inline bool streamReadProp(std::istream &ss, Dict::InternalPair &pair,
+                           bool &dictHasNonPOD,
                            const CustomPropHandlerVec &handlers = {}) {
+  std::string strKey;
   int version = 0;
-  streamRead(ss, pair.key, version);
+  streamRead(ss, strKey, version);
+  pair.key = internKey(strKey);
 
   unsigned char type;
   streamRead(ss, type);
@@ -584,21 +603,27 @@ inline bool streamReadProp(std::istream &ss, Dict::Pair &pair,
 
     case DTags::StringTag:
       readRDValueString(ss, pair.val);
+      dictHasNonPOD = true;
       break;
     case DTags::VecStringTag:
       readRDStringVecValue(ss, pair.val);
+      dictHasNonPOD = true;
       break;
     case DTags::VecIntTag:
       readRDVecValue<int>(ss, pair.val);
+      dictHasNonPOD = true;
       break;
     case DTags::VecUIntTag:
       readRDVecValue<unsigned int>(ss, pair.val);
+      dictHasNonPOD = true;
       break;
     case DTags::VecFloatTag:
       readRDVecValue<float>(ss, pair.val);
+      dictHasNonPOD = true;
       break;
     case DTags::VecDoubleTag:
       readRDVecValue<double>(ss, pair.val);
+      dictHasNonPOD = true;
       break;
     case DTags::CustomTag: {
       std::string propType;
@@ -607,6 +632,7 @@ inline bool streamReadProp(std::istream &ss, Dict::Pair &pair,
       for (auto &handler : handlers) {
         if (propType == handler->getPropName()) {
           handler->read(ss, pair.val);
+          dictHasNonPOD = true;
           return true;
         }
       }
@@ -619,6 +645,19 @@ inline bool streamReadProp(std::istream &ss, Dict::Pair &pair,
   return true;
 }
 
+inline bool streamReadProp(std::istream &ss, Dict::Pair &pair,
+                           bool &dictHasNonPOD,
+                           const CustomPropHandlerVec &handlers = {}) {
+  Dict::InternalPair ipair;
+  bool ok = streamReadProp(ss, ipair, dictHasNonPOD, handlers);
+  if (ok) {
+    pair.key = keyToString(ipair.key);
+    pair.val = ipair.val;
+    ipair.val.type = RDTypeTag::EmptyTag;
+  }
+  return ok;
+}
+
 template <typename COUNT_TYPE = unsigned int>
 inline unsigned int streamReadProps(std::istream &ss, RDProps &props,
                                     const CustomPropHandlerVec &handlers = {},
@@ -628,14 +667,16 @@ inline unsigned int streamReadProps(std::istream &ss, RDProps &props,
 
   Dict &dict = props.getDict();
   if (reset) {
-    dict.reset();  // Clear data before repopulating
+    dict.reset();
   }
-  std::vector<Dict::Pair> pairs(count);
+  auto &idata = dict.getInternalData();
+  auto startSz = idata.size();
+  idata.resize(startSz + count);
   for (unsigned index = 0; index < count; ++index) {
-    CHECK_INVARIANT(streamReadProp(ss, pairs[index], handlers),
+    CHECK_INVARIANT(streamReadProp(ss, idata[startSz + index],
+                                   dict.getNonPODStatus(), handlers),
                     "Corrupted property serialization detected");
   }
-  dict.extend(std::move(pairs));
 
   return static_cast<unsigned int>(count);
 }

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -47,160 +47,148 @@
 namespace RDKit {
 
 namespace detail {
-// used in various places for computed properties
-inline constexpr std::string_view computedPropName = "__computedProps";
+#ifndef SWIG
+inline constexpr DictKey computedPropName = 0;
+#endif
 }  // namespace detail
 
+#ifndef SWIG
 namespace common_properties {
-///////////////////////////////////////////////////////////////
-// Molecule Props
-inline constexpr std::string_view TWOD = "2D";
-inline constexpr std::string_view BalabanJ = "BalabanJ";
-inline constexpr std::string_view BalanbanJ = "BalanbanJ";
-inline constexpr std::string_view Discrims = "Discrims";
-inline constexpr std::string_view DistanceMatrix_Paths = "DistanceMatrix_Paths";
-inline constexpr std::string_view MolFileComments = "MolFileComments";
-inline constexpr std::string_view MolFileInfo = "MolFileInfo";
-inline constexpr std::string_view NullBond = "NullBond";
-inline constexpr std::string_view _2DConf = "_2DConf";
-inline constexpr std::string_view _3DConf = "_3DConf";
-inline constexpr std::string_view _AtomID = "_AtomID";
-inline constexpr std::string_view _BondsPotentialStereo =
-    "_BondsPotentialStereo";
-inline constexpr std::string_view _ChiralAtomRank = "_chiralAtomRank";
-inline constexpr std::string_view _CIPCode = "_CIPCode";
-inline constexpr std::string_view _CIPRank = "_CIPRank";
-inline constexpr std::string_view _CIPComputed = "_CIPComputed";
-inline constexpr std::string_view _CIPNeighborOrder = "_CIPNeighborOrder";
-inline constexpr std::string_view _CanonicalRankingNumber =
-    "_CanonicalRankingNumber";
-inline constexpr std::string_view _ChiralityPossible = "_ChiralityPossible";
-inline constexpr std::string_view _CrippenLogP = "_CrippenLogP";
-inline constexpr std::string_view _CrippenMR = "_CrippenMR";
-inline constexpr std::string_view _MMFFSanitized = "_MMFFSanitized";
-inline constexpr std::string_view _MolFileChiralFlag = "_MolFileChiralFlag";
-inline constexpr std::string_view MRV_SMA = "MRV SMA";
-inline constexpr std::string_view _MolFileRLabel = "_MolFileRLabel";
-inline constexpr std::string_view _MolFileAtomQuery = "_MolFileAtomQuery";
-inline constexpr std::string_view _MolFileBondQuery = "_MolFileBondQuery";
-inline constexpr std::string_view _MolFileBondEndPts = "_MolFileBondEndPts";
-inline constexpr std::string_view _MolFileBondAttach = "_MolFileBondAttach";
-inline constexpr std::string_view _MolFileBondType = "_MolFileBondType";
-inline constexpr std::string_view _MolFileBondStereo = "_MolFileBondStereo";
-inline constexpr std::string_view _MolFileBondCfg = "_MolFileBondCfg";
-
-inline constexpr std::string_view _Name = "_Name";
-inline constexpr std::string_view _NeedsQueryScan = "_NeedsQueryScan";
-inline constexpr std::string_view _NonExplicit3DChirality =
-    "_NonExplicit3DChirality";
-inline constexpr std::string_view _QueryFormalCharge = "_QueryFormalCharge";
-inline constexpr std::string_view _QueryHCount = "_QueryHCount";
-inline constexpr std::string_view _QueryIsotope = "_QueryIsotope";
-inline constexpr std::string_view _QueryMass = "_QueryMass";
-inline constexpr std::string_view _ReactionDegreeChanged =
-    "_ReactionDegreeChanged";
-inline constexpr std::string_view reactantAtomIdx = "react_atom_idx";
-inline constexpr std::string_view reactionMapNum = "old_mapno";
-inline constexpr std::string_view reactantIdx = "react_idx";
-
-inline constexpr std::string_view _RingClosures = "_RingClosures";
-inline constexpr std::string_view _SLN_s = "_SLN_s";
-inline constexpr std::string_view _SmilesStart = "_SmilesStart";
-inline constexpr std::string_view _StereochemDone = "_StereochemDone";
-inline constexpr std::string_view _TraversalBondIndexOrder =
-    "_TraversalBondIndexOrder";
-inline constexpr std::string_view _TraversalRingClosureBond =
-    "_TraversalRingClosureBond";
-inline constexpr std::string_view _TraversalStartPoint = "_TraversalStartPoint";
-inline constexpr std::string_view _TriposAtomType = "_TriposAtomType";
-inline constexpr std::string_view _Unfinished_SLN_ = "_Unfinished_SLN_";
-inline constexpr std::string_view _UnknownStereo = "_UnknownStereo";
-inline constexpr std::string_view _connectivityHKDeltas =
-    "_connectivityHKDeltas";
-inline constexpr std::string_view _connectivityNVals = "_connectivityNVals";
-inline constexpr std::string_view _crippenLogP = "_crippenLogP";
-inline constexpr std::string_view _crippenLogPContribs = "_crippenLogPContribs";
-inline constexpr std::string_view _crippenMR = "_crippenMR";
-inline constexpr std::string_view _crippenMRContribs = "_crippenMRContribs";
-inline constexpr std::string_view _GasteigerCharge = "_GasteigerCharge";
-inline constexpr std::string_view _GasteigerHCharge = "_GasteigerHCharge";
-inline constexpr std::string_view _doIsoSmiles = "_doIsoSmiles";
-inline constexpr std::string_view _fragSMARTS = "_fragSMARTS";
-inline constexpr std::string_view _hasMassQuery = "_hasMassQuery";
-inline constexpr std::string_view _labuteASA = "_labuteASA";
-inline constexpr std::string_view _labuteAtomContribs = "_labuteAtomContribs";
-inline constexpr std::string_view _labuteAtomHContrib = "_labuteAtomHContrib";
-inline constexpr std::string_view _protected = "_protected";
-inline constexpr std::string_view _queryRootAtom = "_queryRootAtom";
-inline constexpr std::string_view _ringStereoAtoms = "_ringStereoAtoms";
-inline constexpr std::string_view _ringStereoWarning = "_ringStereoWarning";
-inline constexpr std::string_view _ringStereochemCand = "_ringStereochemCand";
-inline constexpr std::string_view _ringStereoOtherAtom = "_ringStereoOtherAtom";
-inline constexpr std::string_view _mesoOtherAtom = "_mesoOtherAtom";
-inline constexpr std::string_view _chiralPermutation = "_chiralPermutation";
-inline constexpr std::string_view _smilesAtomOutputOrder =
-    "_smilesAtomOutputOrder";
-inline constexpr std::string_view _smilesBondOutputOrder =
-    "_smilesBondOutputOrder";
-inline constexpr std::string_view _starred = "_starred";
-inline constexpr std::string_view _supplementalSmilesLabel =
-    "_supplementalSmilesLabel";
-inline constexpr std::string_view _tpsa = "_tpsa";
-inline constexpr std::string_view _tpsaAtomContribs = "_tpsaAtomContribs";
-inline constexpr std::string_view _unspecifiedOrder = "_unspecifiedOrder";
-inline constexpr std::string_view _brokenChirality = "_brokenChirality";
-inline constexpr std::string_view _rgroupAtomMaps = "_rgroupAtomMaps";
-inline constexpr std::string_view _rgroupBonds = "_rgroupBonds";
-inline constexpr std::string_view _rgroupTargetAtoms = "_rgroupTargetAtoms";
-inline constexpr std::string_view _rgroupTargetBonds = "_rgroupTargetBonds";
-inline constexpr std::string_view dummyLabel = "dummyLabel";
-inline constexpr std::string_view extraRings = "extraRings";
-inline constexpr std::string_view isImplicit = "isImplicit";
-inline constexpr std::string_view maxAttachIdx = "maxAttachIdx";
-inline constexpr std::string_view molAtomMapNumber = "molAtomMapNumber";
-inline constexpr std::string_view molFileAlias = "molFileAlias";
-inline constexpr std::string_view molFileValue = "molFileValue";
-inline constexpr std::string_view molInversionFlag = "molInversionFlag";
-inline constexpr std::string_view molParity = "molParity";
-inline constexpr std::string_view molStereoCare = "molStereoCare";
-inline constexpr std::string_view molRxnComponent = "molRxnComponent";
-inline constexpr std::string_view molRxnRole = "molRxnRole";
-inline constexpr std::string_view molTotValence = "molTotValence";
-inline constexpr std::string_view molFileLinkNodes = "_molLinkNodes";
-inline constexpr std::string_view numArom = "numArom";
-inline constexpr std::string_view ringMembership = "ringMembership";
-inline constexpr std::string_view smilesSymbol = "smilesSymbol";
-inline constexpr std::string_view atomLabel = "atomLabel";
-inline constexpr std::string_view OxidationNumber = "OxidationNumber";
-inline constexpr std::string_view internalRgroupSmiles = "internalRgroupSmiles";
-inline constexpr std::string_view molRingBondCount = "molRingBondCount";
-inline constexpr std::string_view molSubstCount = "molSubstCount";
-inline constexpr std::string_view molAttachPoint = "molAttchpt";
-inline constexpr std::string_view molAttachOrder = "molAttchord";
-inline constexpr std::string_view molAttachOrderTemplate =
-    "molAttachOrderTemplate";
-inline constexpr std::string_view molAtomClass = "molClass";
-inline constexpr std::string_view molAtomSeqId = "molSeqid";
-inline constexpr std::string_view molAtomSeqName = "molSeqName";
-inline constexpr std::string_view molRxnExactChange = "molRxnExachg";
-inline constexpr std::string_view molReactStatus = "molReactStatus";
-inline constexpr std::string_view _fromAttachPoint = "_fromAttchpt";
-inline constexpr std::string_view natReplace = "natReplace";
-inline constexpr std::string_view templateNames = "templateNames";
-
-inline constexpr std::string_view molNote = "molNote";
-inline constexpr std::string_view atomNote = "atomNote";
-inline constexpr std::string_view bondNote = "bondNote";
-inline constexpr std::string_view _isotopicHs = "_isotopicHs";
-
-inline constexpr std::string_view _QueryAtomGenericLabel =
-    "_QueryAtomGenericLabel";
-
-// molecule drawing
-inline constexpr std::string_view _displayLabel = "_displayLabel";
-inline constexpr std::string_view _displayLabelW = "_displayLabelW";
-
+inline constexpr DictKey TWOD = 1;
+inline constexpr DictKey BalabanJ = 2;
+inline constexpr DictKey BalanbanJ = 3;
+inline constexpr DictKey Discrims = 4;
+inline constexpr DictKey DistanceMatrix_Paths = 5;
+inline constexpr DictKey MolFileComments = 6;
+inline constexpr DictKey MolFileInfo = 7;
+inline constexpr DictKey NullBond = 8;
+inline constexpr DictKey _2DConf = 9;
+inline constexpr DictKey _3DConf = 10;
+inline constexpr DictKey _AtomID = 11;
+inline constexpr DictKey _BondsPotentialStereo = 12;
+inline constexpr DictKey _ChiralAtomRank = 13;
+inline constexpr DictKey _CIPCode = 14;
+inline constexpr DictKey _CIPRank = 15;
+inline constexpr DictKey _CIPComputed = 16;
+inline constexpr DictKey _CIPNeighborOrder = 17;
+inline constexpr DictKey _CanonicalRankingNumber = 18;
+inline constexpr DictKey _ChiralityPossible = 19;
+inline constexpr DictKey _CrippenLogP = 20;
+inline constexpr DictKey _CrippenMR = 21;
+inline constexpr DictKey _MMFFSanitized = 22;
+inline constexpr DictKey _MolFileChiralFlag = 23;
+inline constexpr DictKey MRV_SMA = 24;
+inline constexpr DictKey _MolFileRLabel = 25;
+inline constexpr DictKey _MolFileAtomQuery = 26;
+inline constexpr DictKey _MolFileBondQuery = 27;
+inline constexpr DictKey _MolFileBondEndPts = 28;
+inline constexpr DictKey _MolFileBondAttach = 29;
+inline constexpr DictKey _MolFileBondType = 30;
+inline constexpr DictKey _MolFileBondStereo = 31;
+inline constexpr DictKey _MolFileBondCfg = 32;
+inline constexpr DictKey _Name = 33;
+inline constexpr DictKey _NeedsQueryScan = 34;
+inline constexpr DictKey _NonExplicit3DChirality = 35;
+inline constexpr DictKey _QueryFormalCharge = 36;
+inline constexpr DictKey _QueryHCount = 37;
+inline constexpr DictKey _QueryIsotope = 38;
+inline constexpr DictKey _QueryMass = 39;
+inline constexpr DictKey _ReactionDegreeChanged = 40;
+inline constexpr DictKey reactantAtomIdx = 41;
+inline constexpr DictKey reactionMapNum = 42;
+inline constexpr DictKey reactantIdx = 43;
+inline constexpr DictKey _RingClosures = 44;
+inline constexpr DictKey _SLN_s = 45;
+inline constexpr DictKey _SmilesStart = 46;
+inline constexpr DictKey _StereochemDone = 47;
+inline constexpr DictKey _TraversalBondIndexOrder = 48;
+inline constexpr DictKey _TraversalRingClosureBond = 49;
+inline constexpr DictKey _TraversalStartPoint = 50;
+inline constexpr DictKey _TriposAtomType = 51;
+inline constexpr DictKey _Unfinished_SLN_ = 52;
+inline constexpr DictKey _UnknownStereo = 53;
+inline constexpr DictKey _connectivityHKDeltas = 54;
+inline constexpr DictKey _connectivityNVals = 55;
+inline constexpr DictKey _crippenLogP = 56;
+inline constexpr DictKey _crippenLogPContribs = 57;
+inline constexpr DictKey _crippenMR = 58;
+inline constexpr DictKey _crippenMRContribs = 59;
+inline constexpr DictKey _GasteigerCharge = 60;
+inline constexpr DictKey _GasteigerHCharge = 61;
+inline constexpr DictKey _doIsoSmiles = 62;
+inline constexpr DictKey _fragSMARTS = 63;
+inline constexpr DictKey _hasMassQuery = 64;
+inline constexpr DictKey _labuteASA = 65;
+inline constexpr DictKey _labuteAtomContribs = 66;
+inline constexpr DictKey _labuteAtomHContrib = 67;
+inline constexpr DictKey _protected = 68;
+inline constexpr DictKey _queryRootAtom = 69;
+inline constexpr DictKey _ringStereoAtoms = 70;
+inline constexpr DictKey _ringStereoWarning = 71;
+inline constexpr DictKey _ringStereochemCand = 72;
+inline constexpr DictKey _ringStereoOtherAtom = 73;
+inline constexpr DictKey _mesoOtherAtom = 74;
+inline constexpr DictKey _chiralPermutation = 75;
+inline constexpr DictKey _smilesAtomOutputOrder = 76;
+inline constexpr DictKey _smilesBondOutputOrder = 77;
+inline constexpr DictKey _starred = 78;
+inline constexpr DictKey _supplementalSmilesLabel = 79;
+inline constexpr DictKey _tpsa = 80;
+inline constexpr DictKey _tpsaAtomContribs = 81;
+inline constexpr DictKey _unspecifiedOrder = 82;
+inline constexpr DictKey _brokenChirality = 83;
+inline constexpr DictKey _rgroupAtomMaps = 84;
+inline constexpr DictKey _rgroupBonds = 85;
+inline constexpr DictKey _rgroupTargetAtoms = 86;
+inline constexpr DictKey _rgroupTargetBonds = 87;
+inline constexpr DictKey dummyLabel = 88;
+inline constexpr DictKey extraRings = 89;
+inline constexpr DictKey isImplicit = 90;
+inline constexpr DictKey maxAttachIdx = 91;
+inline constexpr DictKey molAtomMapNumber = 92;
+inline constexpr DictKey molFileAlias = 93;
+inline constexpr DictKey molFileValue = 94;
+inline constexpr DictKey molInversionFlag = 95;
+inline constexpr DictKey molParity = 96;
+inline constexpr DictKey molStereoCare = 97;
+inline constexpr DictKey molRxnComponent = 98;
+inline constexpr DictKey molRxnRole = 99;
+inline constexpr DictKey molTotValence = 100;
+inline constexpr DictKey molFileLinkNodes = 101;
+inline constexpr DictKey numArom = 102;
+inline constexpr DictKey ringMembership = 103;
+inline constexpr DictKey smilesSymbol = 104;
+inline constexpr DictKey atomLabel = 105;
+inline constexpr DictKey OxidationNumber = 106;
+inline constexpr DictKey internalRgroupSmiles = 107;
+inline constexpr DictKey molRingBondCount = 108;
+inline constexpr DictKey molSubstCount = 109;
+inline constexpr DictKey molAttachPoint = 110;
+inline constexpr DictKey molAttachOrder = 111;
+inline constexpr DictKey molAttachOrderTemplate = 112;
+inline constexpr DictKey molAtomClass = 113;
+inline constexpr DictKey molAtomSeqId = 114;
+inline constexpr DictKey molAtomSeqName = 115;
+inline constexpr DictKey molRxnExactChange = 116;
+inline constexpr DictKey molReactStatus = 117;
+inline constexpr DictKey _fromAttachPoint = 118;
+inline constexpr DictKey natReplace = 119;
+inline constexpr DictKey templateNames = 120;
+inline constexpr DictKey molNote = 121;
+inline constexpr DictKey atomNote = 122;
+inline constexpr DictKey bondNote = 123;
+inline constexpr DictKey _isotopicHs = 124;
+inline constexpr DictKey _QueryAtomGenericLabel = 125;
+inline constexpr DictKey _displayLabel = 126;
+inline constexpr DictKey _displayLabelW = 127;
+inline constexpr DictKey _cxsmilesBondIdx = 128;
+inline constexpr DictKey _cxsmilesOutputIndex = 129;
+inline constexpr DictKey _needsDetectAtomStereo = 130;
+inline constexpr DictKey _needsDetectBondStereo = 131;
+inline constexpr DictKey _potentialStereo = 132;
+inline constexpr DictKey _stereoGroup = 133;
 }  // namespace common_properties
+#endif  // SWIG
 #ifndef WIN32
 typedef long long int LONGINT;
 #else


### PR DESCRIPTION
*summary by opus-4.6 via opencode:*

Replace `std::string` keys in Dict with interned `uint16_t` keys (`DictKey`), and change `common_properties` from `string_view` to `DictKey` so existing call sites automatically use integer key lookups with zero source changes.

**Architecture:**
- `DictKeyIntern` singleton maps strings → uint16 via thread-safe shared_mutex, pre-populated with 134 well-known property names
- Dict storage uses `vector<InternalPair{DictKey, RDValue}>` instead of `vector<Pair{string, RDValue}>`
- `common_properties` members changed from `string_view` to `DictKey` (uint16_t indices 1–133)
- Thread-local 64-entry flat hash cache in `internKey()` for dynamic property names
- `#ifndef SWIG` guards hide `common_properties` and `detail::computedPropName` from Java wrapper generation

**Benchmark (16 rounds × 800 samples, interleaved, Bonferroni-corrected α=0.002):**
- `MolToCXSmiles`: **-5.3%** (p=0.0017)

1/26 significant. No regressions.

<details>
<summary>Benchmark Results (vs master)</summary>

| Benchmark | Old (mean±sd) | New (mean±sd) | Δ% | CV | Speed | Sig(p) |
|:---|---:|---:|---:|---:|:---|:---|
| bench_common::nth_random | 1.4 ns ± 0.126 ns | 1.42 ns ± 0.133 ns | +1.6% | 9.3% | 1.02× slower | ns p=0.619 |
| Chirality::findPotentialStereo | 1.59 ms ± 72.3 us | 1.58 ms ± 61.8 us | -0.5% | 4.6% | 1.01× faster | ns p=0.736 |
| CIPLabeler::assignCIPLabels | 589 ms ± 36.1 ms | 594 ms ± 20.7 ms | +0.7% | 6.1% | 1.01× slower | ns p=0.699 |
| Descriptors::calcNumBridgeheadAtoms | 4.41 us ± 496 ns | 4.18 us ± 355 ns | -5.4% | 11.2% | 1.06× faster | ns p=0.132 |
| Descriptors::calcNumSpiroAtoms | 4.85 us ± 438 ns | 5.01 us ± 526 ns | +3.2% | 10.5% | 1.03× slower | ns p=0.375 |
| InchiToInchiKey | 49.8 us ± 4.36 us | 50.2 us ± 4.41 us | +0.7% | 8.8% | 1.01× slower | ns p=0.814 |
| InchiToMol | 10.5 ms ± 237 us | 10.6 ms ± 175 us | +0.7% | 2.3% | 1.01× slower | ns p=0.352 |
| memory pressure test | 18.5 us ± 3.43 us | 17.3 us ± 2.2 us | -6.3% | 18.5% | 1.07× faster | ns p=0.262 |
| MolOps::addHs | 805 us ± 50.3 us | 800 us ± 32.9 us | -0.6% | 6.3% | 1.01× faster | ns p=0.764 |
| MolOps::assignStereochemistry legacy=false | 1.95 ms ± 101 us | 1.9 ms ± 48.5 us | -2.4% | 5.2% | 1.02× faster | ns p=0.114 |
| MolOps::assignStereochemistry legacy=true | 1.14 ms ± 51.4 us | 1.09 ms ± 37.1 us | -4.0% | 4.5% | 1.04× faster | ns p=0.0072 |
| MolOps::FindSSR | 369 us ± 16.5 us | 373 us ± 20.3 us | +1.0% | 5.4% | 1.01× slower | ns p=0.595 |
| MolOps::getMolFrags | 2.33 ms ± 120 us | 2.27 ms ± 68.7 us | -2.5% | 5.1% | 1.03× faster | ns p=0.1 |
| MolPickler::molFromPickle | 302 us ± 22.2 us | 311 us ± 13 us | +3.2% | 7.4% | 1.03× slower | ns p=0.148 |
| MolPickler::pickleMol | 278 us ± 18.3 us | 272 us ± 12.6 us | -2.3% | 6.6% | 1.02× faster | ns p=0.264 |
| MolToCXSmiles | 2.64 ms ± 142 us | 2.5 ms ± 69.1 us | -5.3% | 5.4% | 1.06× faster | sig p=0.00174 |
| MolToInchi | 6.1 ms ± 122 us | 6.15 ms ± 132 us | +0.8% | 2.2% | 1.01× slower | ns p=0.275 |
| MolToSmiles | 1.99 ms ± 111 us | 1.9 ms ± 54.8 us | -4.3% | 5.6% | 1.05× faster | ns p=0.0107 |
| MorganFingerprints::getFingerprint | 614 us ± 24.6 us | 617 us ± 21.6 us | +0.4% | 4.0% | 1.00× slower | ns p=0.768 |
| ROMol copy constructor | 148 us ± 11.8 us | 139 us ± 8.59 us | -6.3% | 7.9% | 1.07× faster | ns p=0.0156 |
| ROMol destructor | 63 us ± 4.26 us | 60 us ± 4.55 us | -4.8% | 7.6% | 1.05× faster | ns p=0.0631 |
| ROMol::getNumHeavyAtoms | 355 ns ± 28.8 ns | 347 ns ± 27.6 ns | -2.1% | 8.1% | 1.02× faster | ns p=0.456 |
| ROMol::GetSubstructMatch | 116 us ± 8.21 us | 108 us ± 8.88 us | -6.8% | 8.2% | 1.07× faster | ns p=0.0142 |
| ROMol::GetSubstructMatch patty | 3.61 ms ± 79 us | 3.59 ms ± 65.4 us | -0.7% | 2.2% | 1.01× faster | ns p=0.337 |
| ROMol::GetSubstructMatch RLewis | 22.1 ms ± 375 us | 22 ms ± 187 us | -0.4% | 1.7% | 1.00× faster | ns p=0.433 |
| SmilesToMol | 2.91 ms ± 112 us | 2.89 ms ± 80 us | -0.7% | 3.8% | 1.01× faster | ns p=0.577 |

_Summary: sig=1, below=0 (stat-sig but < threshold), ns=25, missing=0, new_only=0
Bonferroni-corrected α = 0.001923 (26 tests, family α = 0.05)_

</details>
