### PR TITLE
perf: skip unique-rank atoms in iterateCIPRanks inner loop

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -1254,23 +1254,32 @@ void iterateCIPRanks(const ROMol &mol, const DOUBLE_VECT &invars,
 
   PrecomputedBondFeatures bondFeatures = computeBondFeatures(mol);
 
+  boost::dynamic_bitset<> inTiedSegment(numAtoms);
+  auto markTiedAtoms = [&]() {
+    inTiedSegment.reset();
+    for (const auto &[firstIdx, lastIdx] : needsSorting) {
+      for (int i = firstIdx; i <= lastIdx; ++i) {
+        inTiedSegment.set(sortableEntries[i].atomIdx);
+      }
+    }
+  };
+  markTiedAtoms();
+
   while (!needsSorting.empty() && numIts < maxIts &&
          (lastNumRanks < 0 ||
           static_cast<unsigned int>(lastNumRanks) < numRanks)) {
-    // ----------------------------------------------------
-    //
-    // for each atom, get a sorted list of its neighbors' ranks:
-    //
     for (unsigned int index = 0; index < numAtoms; ++index) {
+      if (!inTiedSegment[index]) {
+        continue;
+      }
+
       const unsigned int indexOffset = kMaxBonds * index;
       const int numNeighbors = bondFeatures.numNeighbors[index];
 
       auto *sortBegin = &bondFeatures.countsAndNeighborIndices[indexOffset];
       auto *sortEnd = sortBegin + numNeighbors + 1;
 
-      // For each of our neighbors' ranks weighted by bond type, copy it N times
-      // to our cipEntry in reverse rank order, where N is the weight.
-      if (numNeighbors > 1) {  // compare vs 1 for performance.
+      if (numNeighbors > 1) {
         std::sort(sortBegin, sortEnd,
                   [&ranks](const std::pair<std::uint8_t, int> &countAndIdx1,
                            const std::pair<std::uint8_t, int> &countAndIdx2) {
@@ -1283,27 +1292,21 @@ void iterateCIPRanks(const ROMol &mol, const DOUBLE_VECT &invars,
         const auto &[count, idx] = *iter;
         cipEntry.insert(cipEntry.end(), count, ranks[idx] + 1);
       }
-      // add a zero for each coordinated H as long as we're not a query atom
       if (!mol[index]->hasQuery()) {
         cipEntry.insert(cipEntry.end(), mol[index]->getTotalNumHs(), 0);
       }
     }
-    // ----------------------------------------------------
-    //
-    // sort the new ranks and update the list of active indices:
-    //
+
     lastNumRanks = numRanks;
 
-    // Loop through previously tied atom sections and re-sort.
     for (const auto &[firstIdx, lastIdx] : needsSorting) {
       std::sort(sortableEntries.begin() + firstIdx,
                 sortableEntries.begin() + lastIdx + 1);
     }
     findSegmentsToResort(sortableEntries, needsSorting, numRanks);
-    // Map out of order rankings back to the absolute rankings vector.
     recomputeRanks(sortableEntries, ranks);
+    markTiedAtoms();
 
-    // now truncate each vector and stick the rank at the end
     if (static_cast<unsigned int>(lastNumRanks) != numRanks) {
       for (unsigned int i = 0; i < numAtoms; ++i) {
         cipEntries[i].resize(cipRankIndex + 1);


### PR DESCRIPTION
*summary by opus-4.6 via opencode:*

Skip atoms that already have a unique rank in the `iterateCIPRanks` inner loop. Atoms with unique ranks cannot change relative position in subsequent iterations, so the neighbor-rank accumulation is wasted work for them.

A `boost::dynamic_bitset` tracks which atoms are in tied segments (from `findSegmentsToResort`), and only those atoms participate in the inner loop.

**Benchmark (16 rounds × 800 samples, interleaved, Bonferroni-corrected α=0.002):**
No significant results (0/26).

<details>
<summary>Benchmark Results (vs master)</summary>

| Benchmark | Old (mean±sd) | New (mean±sd) | Δ% | CV | Speed | Sig(p) |
|:---|---:|---:|---:|---:|:---|:---|
| bench_common::nth_random | 1.41 ns ± 0.115 ns | 1.3 ns ± 0.131 ns | -7.6% | 10.1% | 1.08× faster | ns p=0.0198 |
| Chirality::findPotentialStereo | 1.59 ms ± 57 us | 1.58 ms ± 68.7 us | -0.4% | 4.3% | 1.00× faster | ns p=0.798 |
| CIPLabeler::assignCIPLabels | 583 ms ± 32.5 ms | 574 ms ± 33.6 ms | -1.4% | 5.8% | 1.01× faster | ns p=0.483 |
| Descriptors::calcNumBridgeheadAtoms | 4.51 us ± 452 ns | 4.28 us ± 453 ns | -5.1% | 10.6% | 1.05× faster | ns p=0.16 |
| Descriptors::calcNumSpiroAtoms | 5.28 us ± 486 ns | 5.13 us ± 505 ns | -2.7% | 9.8% | 1.03× faster | ns p=0.423 |
| InchiToInchiKey | 50 us ± 5.41 us | 50.7 us ± 4.04 us | +1.3% | 10.8% | 1.01× slower | ns p=0.713 |
| InchiToMol | 10.5 ms ± 189 us | 10.5 ms ± 218 us | -0.0% | 2.1% | 1.00× faster | ns p=0.989 |
| memory pressure test | 17.8 us ± 3.76 us | 16.4 us ± 2.89 us | -7.7% | 21.1% | 1.08× faster | ns p=0.257 |
| MolOps::addHs | 772 us ± 40 us | 797 us ± 22.6 us | +3.3% | 5.2% | 1.03× slower | ns p=0.0363 |
| MolOps::assignStereochemistry legacy=false | 1.93 ms ± 75 us | 1.92 ms ± 54.6 us | -0.3% | 3.9% | 1.00× faster | ns p=0.829 |
| MolOps::assignStereochemistry legacy=true | 1.11 ms ± 38.7 us | 1.08 ms ± 35.9 us | -2.4% | 3.5% | 1.02× faster | ns p=0.0573 |
| MolOps::FindSSR | 376 us ± 19.1 us | 377 us ± 23.3 us | +0.1% | 6.2% | 1.00× slower | ns p=0.955 |
| MolOps::getMolFrags | 2.29 ms ± 93.1 us | 2.29 ms ± 98.4 us | -0.2% | 4.3% | 1.00× faster | ns p=0.873 |
| MolPickler::molFromPickle | 301 us ± 20.2 us | 301 us ± 17 us | -0.1% | 6.7% | 1.00× faster | ns p=0.953 |
| MolPickler::pickleMol | 281 us ± 16.4 us | 276 us ± 18 us | -1.7% | 6.5% | 1.02× faster | ns p=0.434 |
| MolToCXSmiles | 2.57 ms ± 118 us | 2.57 ms ± 88 us | +0.3% | 4.6% | 1.00× slower | ns p=0.858 |
| MolToInchi | 6.1 ms ± 113 us | 6.13 ms ± 97.5 us | +0.5% | 1.9% | 1.01× slower | ns p=0.391 |
| MolToSmiles | 1.98 ms ± 116 us | 1.99 ms ± 65.8 us | +0.1% | 5.8% | 1.00× slower | ns p=0.95 |
| MorganFingerprints::getFingerprint | 613 us ± 22.3 us | 625 us ± 23.6 us | +1.9% | 3.8% | 1.02× slower | ns p=0.155 |
| ROMol copy constructor | 148 us ± 10.2 us | 148 us ± 9.26 us | -0.0% | 6.9% | 1.00× faster | ns p=1 |
| ROMol destructor | 61.7 us ± 4.23 us | 62.8 us ± 3.36 us | +1.8% | 6.9% | 1.02× slower | ns p=0.412 |
| ROMol::getNumHeavyAtoms | 363 ns ± 31.8 ns | 348 ns ± 27.5 ns | -4.1% | 8.8% | 1.04× faster | ns p=0.164 |
| ROMol::GetSubstructMatch | 115 us ± 10.6 us | 110 us ± 8.51 us | -4.5% | 9.2% | 1.05× faster | ns p=0.14 |
| ROMol::GetSubstructMatch patty | 3.62 ms ± 60.1 us | 3.65 ms ± 91.9 us | +0.8% | 2.5% | 1.01× slower | ns p=0.279 |
| ROMol::GetSubstructMatch RLewis | 22.2 ms ± 343 us | 22 ms ± 335 us | -1.1% | 1.5% | 1.01× faster | ns p=0.0436 |
| SmilesToMol | 2.99 ms ± 80.9 us | 2.97 ms ± 91.4 us | -0.7% | 3.1% | 1.01× faster | ns p=0.492 |

_Summary: sig=0, below=0 (stat-sig but < threshold), ns=26, missing=0, new_only=0
Bonferroni-corrected α = 0.001923 (26 tests, family α = 0.05)_

</details>
