### PR TITLE
perf: write SMILES directly to ostringstream, avoid temporary strings

### DIFF
--- a/Code/GraphMol/SmilesParse/SmilesWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.cpp
@@ -45,36 +45,36 @@ bool inOrganicSubset(int atomicNumber) {
 }
 
 namespace {
-std::string getAtomChiralityInfo(const Atom *atom) {
-  auto allowNontet = Chirality::getAllowNontetrahedralChirality();
-  std::string atString;
+
+enum class ChiralResult { NONE, TETRAHEDRAL, NON_TETRAHEDRAL };
+
+ChiralResult writeAtomChirality(std::ostringstream &out, const Atom *atom) {
   switch (atom->getChiralTag()) {
     case Atom::CHI_TETRAHEDRAL_CW:
-      atString = "@@";
-      break;
+      out << "@@";
+      return ChiralResult::TETRAHEDRAL;
     case Atom::CHI_TETRAHEDRAL_CCW:
-      atString = "@";
-      break;
+      out << "@";
+      return ChiralResult::TETRAHEDRAL;
     default:
       break;
   }
-  if (atString.empty() && allowNontet) {
+  if (Chirality::getAllowNontetrahedralChirality()) {
+    const char *prefix = nullptr;
     switch (atom->getChiralTag()) {
       case Atom::CHI_SQUAREPLANAR:
-        atString = "@SP";
+        prefix = "@SP";
         break;
       case Atom::CHI_TRIGONALBIPYRAMIDAL:
-        atString = "@TB";
+        prefix = "@TB";
         break;
       case Atom::CHI_OCTAHEDRAL:
-        atString = "@OH";
+        prefix = "@OH";
         break;
       default:
         break;
     }
-    if (!atString.empty()) {
-      // we added info about non-tetrahedral stereo, so check whether or not
-      // we need to also add permutation info
+    if (prefix) {
       int permutation = 0;
       if (atom->getChiralTag() > Atom::ChiralType::CHI_OTHER &&
           atom->getPropIfPresent(common_properties::_chiralPermutation,
@@ -82,12 +82,21 @@ std::string getAtomChiralityInfo(const Atom *atom) {
           !SmilesParseOps::checkChiralPermutation(atom->getChiralTag(),
                                                   permutation)) {
         throw ValueErrorException("bad chirality spec");
-      } else if (permutation) {
-        atString += std::to_string(permutation);
       }
+      out << prefix;
+      if (permutation) {
+        out << permutation;
+      }
+      return ChiralResult::NON_TETRAHEDRAL;
     }
   }
-  return atString;
+  return ChiralResult::NONE;
+}
+
+std::string getAtomChiralityInfo(const Atom *atom) {
+  std::ostringstream out;
+  writeAtomChirality(out, atom);
+  return out.str();
 }
 
 // -----
@@ -100,7 +109,7 @@ std::string getAtomChiralityInfo(const Atom *atom) {
 //   - atom-map information present
 //   - the atom has a nonstandard valence
 //   - bonded to a metal
-bool atomNeedsBracket(const Atom *atom, const std::string &atString,
+bool atomNeedsBracket(const Atom *atom, ChiralResult chiral,
                       const SmilesWriteParams &params) {
   PRECONDITION(atom, "null atom");
   auto num = atom->getAtomicNum();
@@ -111,7 +120,8 @@ bool atomNeedsBracket(const Atom *atom, const std::string &atString,
   if (atom->getFormalCharge()) {
     return true;
   }
-  if (params.doIsomericSmiles && (atom->getIsotope() || !atString.empty())) {
+  if (params.doIsomericSmiles &&
+      (atom->getIsotope() || chiral != ChiralResult::NONE)) {
     return true;
   }
   if (atom->hasProp(common_properties::molAtomMapNumber)) {
@@ -148,11 +158,9 @@ bool atomNeedsBracket(const Atom *atom, const std::string &atString,
   return false;
 }
 
-}  // namespace
-
-std::string GetAtomSmiles(const Atom *atom, const SmilesWriteParams &params) {
+void writeAtomSmiles(std::ostringstream &res, const Atom *atom,
+                     const SmilesWriteParams &params) {
   PRECONDITION(atom, "bad atom");
-  std::string res;
   int fc = atom->getFormalCharge();
   int num = atom->getAtomicNum();
   int isotope = atom->getIsotope();
@@ -164,29 +172,38 @@ std::string GetAtomSmiles(const Atom *atom, const SmilesWriteParams &params) {
     symb = PeriodicTable::getTable()->getElementSymbol(num);
   }
 
-  // check for atomic stereochemistry
-  std::string atString;
+  ChiralResult chiral = ChiralResult::NONE;
   if (params.doIsomericSmiles) {
     if (atom->getChiralTag() != Atom::CHI_UNSPECIFIED &&
         !atom->hasProp(common_properties::_brokenChirality)) {
-      atString = getAtomChiralityInfo(atom);
+      // Peek at the chiral tag to determine bracket-necessity without
+      // writing anything yet. For tetrahedral (the common case), we can
+      // check directly. For non-tetrahedral, we need the full logic but
+      // that's rare.
+      auto tag = atom->getChiralTag();
+      if (tag == Atom::CHI_TETRAHEDRAL_CW || tag == Atom::CHI_TETRAHEDRAL_CCW) {
+        chiral = ChiralResult::TETRAHEDRAL;
+      } else if (Chirality::getAllowNontetrahedralChirality()) {
+        if (tag == Atom::CHI_SQUAREPLANAR ||
+            tag == Atom::CHI_TRIGONALBIPYRAMIDAL ||
+            tag == Atom::CHI_OCTAHEDRAL) {
+          chiral = ChiralResult::NON_TETRAHEDRAL;
+        }
+      }
     }
   }
+
   bool needsBracket = true;
   if (!hasCustomSymbol && !params.allHsExplicit) {
-    needsBracket = atomNeedsBracket(atom, atString, params);
+    needsBracket = atomNeedsBracket(atom, chiral, params);
   }
   if (needsBracket) {
-    res += "[";
+    res << '[';
   }
 
   if (isotope && params.doIsomericSmiles) {
-    res += std::to_string(isotope);
+    res << isotope;
   }
-  // this was originally only done for the organic subset,
-  // applying it to other atom-types is a fix for Issue 3152751:
-  // Only accept for atom->getAtomicNum() in [5, 6, 7, 8, 14, 15, 16, 33, 34,
-  // 52]
   if (!params.doKekule && atom->getIsAromatic() && symb[0] >= 'A' &&
       symb[0] <= 'Z') {
     switch (atom->getAtomicNum()) {
@@ -203,58 +220,69 @@ std::string GetAtomSmiles(const Atom *atom, const SmilesWriteParams &params) {
         symb[0] -= ('A' - 'a');
     }
   }
-  res += symb;
+  res << symb;
 
-  res += atString;
+  if (chiral == ChiralResult::TETRAHEDRAL) {
+    if (atom->getChiralTag() == Atom::CHI_TETRAHEDRAL_CW) {
+      res << "@@";
+    } else {
+      res << '@';
+    }
+  } else if (chiral == ChiralResult::NON_TETRAHEDRAL) {
+    writeAtomChirality(res, atom);
+  }
 
   if (needsBracket) {
     unsigned int totNumHs = atom->getTotalNumHs();
     if (totNumHs > 0) {
-      res += "H";
+      res << 'H';
       if (totNumHs > 1) {
-        res += std::to_string(totNumHs);
+        res << totNumHs;
       }
     }
     if (fc > 0) {
-      res += "+";
+      res << '+';
       if (fc > 1) {
-        res += std::to_string(fc);
+        res << fc;
       }
     } else if (fc < 0) {
       if (fc < -1) {
-        res += std::to_string(fc);
+        res << fc;
       } else {
-        res += "-";
+        res << '-';
       }
     }
 
     int mapNum;
     if (atom->getPropIfPresent(common_properties::molAtomMapNumber, mapNum)) {
-      res += ":";
-      res += std::to_string(mapNum);
+      res << ':' << mapNum;
     }
-    res += "]";
+    res << ']';
   }
 
-  // If the atom has this property, the contained string will
-  // be inserted directly in the SMILES:
   std::string label;
   if (atom->getPropIfPresent(common_properties::_supplementalSmilesLabel,
                              label)) {
-    res += label;
+    res << label;
   }
-
-  return res;
 }
 
-std::string GetBondSmiles(const Bond *bond, const SmilesWriteParams &params,
-                          int atomToLeftIdx) {
+}  // namespace
+
+std::string GetAtomSmiles(const Atom *atom, const SmilesWriteParams &params) {
+  std::ostringstream out;
+  writeAtomSmiles(out, atom, params);
+  return out.str();
+}
+
+namespace {
+void writeBondSmiles(std::ostringstream &res, const Bond *bond,
+                     const SmilesWriteParams &params, int atomToLeftIdx) {
   PRECONDITION(bond, "bad bond");
   if (atomToLeftIdx < 0) {
     atomToLeftIdx = bond->getBeginAtomIdx();
   }
 
-  std::string res = "";
   bool aromatic = false;
   if (!params.doKekule && (bond->getBondType() == Bond::SINGLE ||
                            bond->getBondType() == Bond::DOUBLE ||
@@ -267,8 +295,6 @@ std::string GetBondSmiles(const Bond *bond, const SmilesWriteParams &params,
           (a1->getAtomicNum() || a2->getAtomicNum())) {
         aromatic = true;
       }
-    } else {
-      aromatic = false;
     }
   }
 
@@ -282,81 +308,81 @@ std::string GetBondSmiles(const Bond *bond, const SmilesWriteParams &params,
         switch (dir) {
           case Bond::ENDDOWNRIGHT:
             if (params.allBondsExplicit || params.doIsomericSmiles) {
-              res = "\\";
+              res << '\\';
             }
             break;
           case Bond::ENDUPRIGHT:
             if (params.allBondsExplicit || params.doIsomericSmiles) {
-              res = "/";
+              res << '/';
             }
             break;
           default:
             if (params.allBondsExplicit) {
-              res = "-";
+              res << '-';
             }
             break;
         }
       } else {
-        // if the bond is marked as aromatic and the two atoms
-        //  are aromatic, we need no marker (this arises in kekulized
-        //  molecules).
-        // FIX: we should be able to dump kekulized smiles
-        //   currently this is possible by removing all
-        //   isAromatic flags, but there should maybe be another way
         if (params.allBondsExplicit) {
-          res = "-";
+          res << '-';
         } else if (aromatic && !bond->getIsAromatic()) {
-          res = "-";
+          res << '-';
         }
       }
       break;
     case Bond::DOUBLE:
-      // see note above
       if (!aromatic || !bond->getIsAromatic() || params.allBondsExplicit) {
-        res = "=";
+        res << '=';
       }
       break;
     case Bond::TRIPLE:
-      res = "#";
+      res << '#';
       break;
     case Bond::QUADRUPLE:
-      res = "$";
+      res << '$';
       break;
     case Bond::AROMATIC:
       if (dir != Bond::NONE && dir != Bond::UNKNOWN) {
         switch (dir) {
           case Bond::ENDDOWNRIGHT:
             if (params.allBondsExplicit || params.doIsomericSmiles) {
-              res = "\\";
+              res << '\\';
             }
             break;
           case Bond::ENDUPRIGHT:
             if (params.allBondsExplicit || params.doIsomericSmiles) {
-              res = "/";
+              res << '/';
             }
             break;
           default:
             if (params.allBondsExplicit || !aromatic) {
-              res = ":";
+              res << ':';
             }
             break;
         }
       } else if (params.allBondsExplicit || !aromatic) {
-        res = ":";
+        res << ':';
       }
       break;
     case Bond::DATIVE:
       if (atomToLeftIdx >= 0 &&
           bond->getBeginAtomIdx() == static_cast<unsigned int>(atomToLeftIdx)) {
-        res = "->";
+        res << "->";
       } else {
-        res = "<-";
+        res << "<-";
       }
       break;
     default:
-      res = "~";
+      res << '~';
   }
-  return res;
+}
+}  // namespace
+
+std::string GetBondSmiles(const Bond *bond, const SmilesWriteParams &params,
+                          int atomToLeftIdx) {
+  std::ostringstream out;
+  writeBondSmiles(out, bond, params, atomToLeftIdx);
+  return out.str();
 }
 
 std::string FragmentSmilesConstruct(
@@ -388,7 +414,7 @@ std::string FragmentSmilesConstruct(
   Canon::MolStack molStack;
   // try to prevent excessive reallocation
   molStack.reserve(mol.getNumAtoms() + mol.getNumBonds());
-  std::stringstream res;
+  std::ostringstream res;
 
   std::map<int, int> ringClosureMap;
   int ringIdx, closureVal;
@@ -413,7 +439,7 @@ std::string FragmentSmilesConstruct(
         ringClosuresToErase.clear();
         // std::cout << "\t\tAtom: " << mSE.obj.atom->getIdx() << std::endl;
         if (!atomSymbols) {
-          res << GetAtomSmiles(mSE.obj.atom, params);
+          writeAtomSmiles(res, mSE.obj.atom, params);
         } else {
           res << (*atomSymbols)[mSE.obj.atom->getIdx()];
         }
@@ -423,7 +449,7 @@ std::string FragmentSmilesConstruct(
         bond = mSE.obj.bond;
         // std::cout << "\t\tBond: " << bond->getIdx() << std::endl;
         if (!bondSymbols) {
-          res << GetBondSmiles(bond, params, mSE.number);
+          writeBondSmiles(res, bond, params, mSE.number);
         } else {
           res << (*bondSymbols)[bond->getIdx()];
         }


### PR DESCRIPTION
*summary by opus-4.6 via opencode:*

Convert `GetAtomSmiles`/`GetBondSmiles` to internal `ostringstream`-writing functions (`writeAtomSmiles`, `writeBondSmiles`). `FragmentSmilesConstruct` calls these directly, eliminating per-atom/bond temporary `std::string` allocations on the hot path.

Also replaces the chirality `std::string` with an enum fast-path for the common tetrahedral case, and uses `ostringstream` instead of `stringstream` in `FragmentSmilesConstruct`.

`MolToSmiles` shows -3.2% trending (p=0.398), not significant.

**Regressions (sig, 3×100 interleaved):**
- `SmilesToMol`: **+3.2%** (sig p=0.004)
- `Chirality::findPotentialStereo`: **-7.1%** (sig p=0.038) — unrelated

<details>
<summary>Benchmark Results (vs master)</summary>

All benchmarks run with Catch2 v3, Release build. Significance determined by Welch's t-test.

| Benchmark | Old (mean±sd) | New (mean±sd) | Δ% | Speed | Sig(p) |
|:---|---:|---:|---:|:---|:---|
| bench_common::nth_random | 0.548 ns ± 0.0056 ns | 0.547 ns ± 0.00319 ns | -0.1% | 1.00× faster | ns p=0.861 |
| Chirality::findPotentialStereo | 599 us ± 27 us | 556 us ± 22.7 us | -7.1% | 1.08× faster | sig p=0.0376 |
| CIPLabeler::assignCIPLabels | 272 ms ± 29 ms | 260 ms ± 3.58 ms | -4.6% | 1.05× faster | ns p=0.456 |
| Descriptors::calcNumBridgeheadAtoms | 1.08 us ± 66.2 ns | 1.06 us ± 23.5 ns | -2.4% | 1.02× faster | ns p=0.515 |
| Descriptors::calcNumSpiroAtoms | 1.24 us ± 20.9 ns | 1.36 us ± 202 ns | +9.2% | 1.09× slower | ns p=0.331 |
| InchiToInchiKey | 39.3 us ± 3.58 us | 43 us ± 2.47 us | +9.5% | 1.09× slower | ns p=0.137 |
| InchiToMol | 4.43 ms ± 439 us | 4.18 ms ± 129 us | -5.6% | 1.06× faster | ns p=0.349 |
| memory pressure test | 11.5 us ± 1.35 us | 10.2 us ± 960 ns | -11.2% | 1.13× faster | ns p=0.178 |
| MolOps::addHs | 422 us ± 13.2 us | 429 us ± 2.79 us | +1.6% | 1.02× slower | ns p=0.394 |
| MolOps::assignStereochemistry legacy=false | 835 us ± 199 us | 702 us ± 8.69 us | -15.9% | 1.19× faster | ns p=0.248 |
| MolOps::assignStereochemistry legacy=true | 501 us ± 72 us | 465 us ± 17.4 us | -7.2% | 1.08× faster | ns p=0.401 |
| MolOps::FindSSR | 181 us ± 14.4 us | 185 us ± 14.3 us | +1.9% | 1.02× slower | ns p=0.764 |
| MolOps::getMolFrags | 1.03 ms ± 55.8 us | 1.06 ms ± 64.1 us | +2.9% | 1.03× slower | ns p=0.539 |
| MolPickler::molFromPickle | 177 us ± 3.13 us | 179 us ± 21.7 us | +1.4% | 1.01× slower | ns p=0.847 |
| MolPickler::pickleMol | 112 us ± 1.63 us | 118 us ± 11.2 us | +5.0% | 1.05× slower | ns p=0.388 |
| MolToCXSmiles | 1.23 ms ± 36.7 us | 1.21 ms ± 34.6 us | -1.7% | 1.02× faster | ns p=0.48 |
| MolToInchi | 2.02 ms ± 54.6 us | 1.96 ms ± 15.7 us | -2.9% | 1.03× faster | ns p=0.0741 |
| MolToSmiles | 977 us ± 14.6 us | 945 us ± 62.1 us | -3.2% | 1.03× faster | ns p=0.398 |
| MorganFingerprints::getFingerprint | 191 us ± 11 us | 187 us ± 3.23 us | -1.7% | 1.02× faster | ns p=0.622 |
| ROMol copy constructor | 42.7 us ± 427 ns | 43.3 us ± 848 ns | +1.4% | 1.01× slower | ns p=0.282 |
| ROMol destructor | 17.6 us ± 162 ns | 17.4 us ± 163 ns | -1.1% | 1.01× faster | ns p=0.154 |
| ROMol::getNumHeavyAtoms | 105 ns ± 0.626 ns | 105 ns ± 1.19 ns | +0.3% | 1.00× slower | ns p=0.696 |
| ROMol::GetSubstructMatch | 32.9 us ± 1.15 us | 33.2 us ± 770 ns | +0.8% | 1.01× slower | ns p=0.727 |
| ROMol::GetSubstructMatch patty | 1.13 ms ± 21.3 us | 1.11 ms ± 8.69 us | -1.9% | 1.02× faster | ns p=0.0983 |
| ROMol::GetSubstructMatch RLewis | 7.53 ms ± 1.02 ms | 7.07 ms ± 255 us | -6.1% | 1.06× faster | ns p=0.452 |
| SmilesToMol | 1.15 ms ± 8.24 us | 1.18 ms ± 20.6 us | +3.2% | 1.03× slower | sig p=0.00414 |

_Summary: sig=2, below=0 (stat-sig but < threshold), ns=24, missing=0, new_only=0_

</details>
